### PR TITLE
feat(testing): opt-in timer cron & ISO-8601 validation rules

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/TimerCronSyntaxRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/TimerCronSyntaxRule.kt
@@ -1,0 +1,35 @@
+package io.miragon.bpmn.domain.validation.rules
+
+import io.miragon.bpmn.domain.validation.BpmnValidationRule
+import io.miragon.bpmn.domain.validation.model.Severity
+import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.ValidationViolation
+
+/**
+ * Opt-in rule: a `timeCycle` timer must contain a valid cron expression.
+ * Only `Cycle` timers are checked — cron has no meaning for `Date` / `Duration` timers, which are
+ * always ISO-8601. Dynamic expressions and blank values are skipped (the latter is the domain of
+ * [MissingTimerDefinitionRule]). The check is syntactic (field count + allowed characters), not a
+ * full engine-specific cron evaluation.
+ */
+class TimerCronSyntaxRule : BpmnValidationRule {
+
+    override val id = "timer-cron-syntax"
+    override val severity = Severity.ERROR
+
+    override fun validate(context: ValidationContext): List<ValidationViolation> {
+        return context.model.timers.mapNotNull { timer ->
+            val (type, value) = timer.getValue()
+            if (type != "Cycle") return@mapNotNull null
+            if (value.isBlank() || TimerValueSyntax.isExpression(value)) return@mapNotNull null
+            if (TimerValueSyntax.isValidCron(value)) return@mapNotNull null
+            ValidationViolation(
+                ruleId = id,
+                severity = severity,
+                elementId = timer.id,
+                processId = context.model.processId,
+                message = "Timer cycle '$value' is not a valid cron expression.",
+            )
+        }
+    }
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/TimerIso8601SyntaxRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/TimerIso8601SyntaxRule.kt
@@ -1,0 +1,39 @@
+package io.miragon.bpmn.domain.validation.rules
+
+import io.miragon.bpmn.domain.validation.BpmnValidationRule
+import io.miragon.bpmn.domain.validation.model.Severity
+import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.ValidationViolation
+
+/**
+ * Opt-in rule: a timer value must be valid ISO-8601 for its type — `Date` -> date/time,
+ * `Duration` -> duration, `Cycle` -> repeating interval.
+ * Dynamic expressions and blank values are skipped (the latter is the domain of
+ * [MissingTimerDefinitionRule]); timers with an unknown/absent type are ignored.
+ */
+class TimerIso8601SyntaxRule : BpmnValidationRule {
+
+    override val id = "timer-iso8601-syntax"
+    override val severity = Severity.ERROR
+
+    override fun validate(context: ValidationContext): List<ValidationViolation> {
+        return context.model.timers.mapNotNull { timer ->
+            val (type, value) = timer.getValue()
+            if (value.isBlank() || TimerValueSyntax.isExpression(value)) return@mapNotNull null
+            val valid = when (type) {
+                "Date" -> TimerValueSyntax.isValidIsoDateTime(value)
+                "Duration" -> TimerValueSyntax.isValidIsoDuration(value)
+                "Cycle" -> TimerValueSyntax.isValidIsoRepeatingInterval(value)
+                else -> return@mapNotNull null
+            }
+            if (valid) return@mapNotNull null
+            ValidationViolation(
+                ruleId = id,
+                severity = severity,
+                elementId = timer.id,
+                processId = context.model.processId,
+                message = "Timer $type value '$value' is not valid ISO-8601.",
+            )
+        }
+    }
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/TimerValueSyntax.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/TimerValueSyntax.kt
@@ -1,0 +1,74 @@
+package io.miragon.bpmn.domain.validation.rules
+
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
+import javax.xml.datatype.DatatypeFactory
+
+/**
+ * Syntactic checks for BPMN timer values, shared by [TimerCronSyntaxRule] and
+ * [TimerIso8601SyntaxRule].
+ * All checks operate on the raw timer value string (the verbatim `timeDate` /
+ * `timeDuration` / `timeCycle` text). Dynamic expressions (Zeebe FEEL `=...`,
+ * Camunda EL) cannot be validated statically — callers detect them via
+ * [isExpression] and skip them.
+ */
+internal object TimerValueSyntax {
+
+    private val datatypeFactory = DatatypeFactory.newInstance()
+
+    private val cronField = Regex("^[0-9A-Za-z*?/,\\-#]+$")
+
+    private val repeatPrefix = Regex("^R\\d*$")
+
+    /**
+     * A dynamic expression (FEEL or Camunda EL) whose value is only
+     * known at runtime.
+     */
+    fun isExpression(value: String): Boolean {
+        return value.startsWith("=") || value.contains("\${") || value.contains("#{")
+    }
+
+    /**
+     * Structural cron check: 6 or 7 whitespace-separated fields
+     * (Quartz / Spring dialects).
+     */
+    fun isValidCron(value: String): Boolean {
+        val fields = value.trim().split(Regex("\\s+"))
+        if (fields.size !in 6..7) return false
+        return fields.all { it.isNotEmpty() && cronField.matches(it) }
+    }
+
+    /**
+     * ISO-8601 duration, e.g. `PT15M`, `P1Y2M`, `P1DT12H`
+     * (full xsd:duration grammar).
+     */
+    fun isValidIsoDuration(value: String): Boolean {
+        return value.startsWith("P") && runCatching { datatypeFactory.newDuration(value) }.isSuccess
+    }
+
+    /**
+     * ISO-8601 point in time, e.g. `2026-01-01T00:00:00Z` or
+     * `2026-01-01T00:00:00`.
+     */
+    fun isValidIsoDateTime(value: String): Boolean {
+        val parsers = listOf<(String) -> Any>(
+            { OffsetDateTime.parse(it) },
+            { ZonedDateTime.parse(it) },
+            { LocalDateTime.parse(it) },
+            { Instant.parse(it) },
+        )
+        return parsers.any { parse -> runCatching { parse(value) }.isSuccess }
+    }
+
+    /**
+     * ISO-8601 repeating interval, e.g. `R3/PT10M` or
+     * `R/2026-01-01T00:00:00Z/PT1H`.
+     */
+    fun isValidIsoRepeatingInterval(value: String): Boolean {
+        val parts = value.split("/")
+        if (parts.size < 2 || !repeatPrefix.matches(parts[0])) return false
+        return parts.drop(1).all { isValidIsoDuration(it) || isValidIsoDateTime(it) }
+    }
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/TimerCronSyntaxRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/TimerCronSyntaxRuleTest.kt
@@ -1,0 +1,66 @@
+package io.miragon.bpmn.domain.validation.rules
+
+import io.miragon.bpmn.domain.shared.FlowNodeDefinition
+import io.miragon.bpmn.domain.shared.FlowNodeProperties
+import io.miragon.bpmn.domain.shared.ProcessEngine
+import io.miragon.bpmn.domain.shared.TimerDefinition
+import io.miragon.bpmn.domain.testBpmnModel
+import io.miragon.bpmn.domain.validation.model.Severity
+import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.ValidationViolation
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TimerCronSyntaxRuleTest {
+
+    private val underTest = TimerCronSyntaxRule()
+
+    @Test
+    fun `has the expected id and severity`() {
+        assertThat(underTest.id).isEqualTo("timer-cron-syntax")
+        assertThat(underTest.severity).isEqualTo(Severity.ERROR)
+    }
+
+    @Test
+    fun `no violation for a valid cron cycle`() {
+        assertThat(validate("Timer_1", "Cycle", "0 0 9 ? * MON-FRI")).isEmpty()
+    }
+
+    @Test
+    fun `reports an error for an invalid cron cycle`() {
+        val violations = validate("Timer_Bad", "Cycle", "not a cron")
+        assertThat(violations).hasSize(1)
+        assertThat(violations.single().elementId).isEqualTo("Timer_Bad")
+        assertThat(violations.single().severity).isEqualTo(Severity.ERROR)
+    }
+
+    @Test
+    fun `reports an error for a cron cycle with the wrong field count`() {
+        assertThat(validate("Timer_Bad", "Cycle", "0 0 9 * *")).hasSize(1)
+    }
+
+    @Test
+    fun `ignores non-cycle timers`() {
+        assertThat(validate("Timer_D", "Duration", "PT15M")).isEmpty()
+        assertThat(validate("Timer_Dt", "Date", "2026-01-01T00:00:00Z")).isEmpty()
+    }
+
+    @Test
+    fun `skips expression and blank values`() {
+        assertThat(validate("Timer_Feel", "Cycle", "=cronVar")).isEmpty()
+        assertThat(validate("Timer_El", "Cycle", "\${cronVar}")).isEmpty()
+        assertThat(validate("Timer_Blank", "Cycle", "")).isEmpty()
+    }
+
+    private fun validate(id: String, type: String?, value: String?): List<ValidationViolation> {
+        val model = testBpmnModel(
+            flowNodes = listOf(
+                FlowNodeDefinition(
+                    id = id,
+                    properties = FlowNodeProperties.Timer(TimerDefinition(id = id, type = type, value = value)),
+                ),
+            ),
+        )
+        return underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+    }
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/TimerIso8601SyntaxRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/TimerIso8601SyntaxRuleTest.kt
@@ -1,0 +1,73 @@
+package io.miragon.bpmn.domain.validation.rules
+
+import io.miragon.bpmn.domain.shared.FlowNodeDefinition
+import io.miragon.bpmn.domain.shared.FlowNodeProperties
+import io.miragon.bpmn.domain.shared.ProcessEngine
+import io.miragon.bpmn.domain.shared.TimerDefinition
+import io.miragon.bpmn.domain.testBpmnModel
+import io.miragon.bpmn.domain.validation.model.Severity
+import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.ValidationViolation
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TimerIso8601SyntaxRuleTest {
+
+    private val underTest = TimerIso8601SyntaxRule()
+
+    @Test
+    fun `has the expected id and severity`() {
+        assertThat(underTest.id).isEqualTo("timer-iso8601-syntax")
+        assertThat(underTest.severity).isEqualTo(Severity.ERROR)
+    }
+
+    @Test
+    fun `no violation for valid iso values per type`() {
+        assertThat(validate("Timer_Date", "Date", "2026-01-01T00:00:00Z")).isEmpty()
+        assertThat(validate("Timer_Dur", "Duration", "PT15M")).isEmpty()
+        assertThat(validate("Timer_Dur2", "Duration", "P1Y2M")).isEmpty()
+        assertThat(validate("Timer_Cyc", "Cycle", "R3/PT10M")).isEmpty()
+    }
+
+    @Test
+    fun `reports an error for an invalid iso duration`() {
+        val violations = validate("Timer_Bad", "Duration", "15 minutes")
+        assertThat(violations).hasSize(1)
+        assertThat(violations.single().elementId).isEqualTo("Timer_Bad")
+        assertThat(violations.single().severity).isEqualTo(Severity.ERROR)
+    }
+
+    @Test
+    fun `reports an error for an invalid iso date`() {
+        assertThat(validate("Timer_Bad", "Date", "01/01/2026")).hasSize(1)
+    }
+
+    @Test
+    fun `reports an error for a cron cycle under the iso rule`() {
+        assertThat(validate("Timer_Bad", "Cycle", "0 0 9 * * ?")).hasSize(1)
+    }
+
+    @Test
+    fun `skips expression and blank values`() {
+        assertThat(validate("Timer_Feel", "Duration", "=durationVar")).isEmpty()
+        assertThat(validate("Timer_El", "Duration", "\${durationVar}")).isEmpty()
+        assertThat(validate("Timer_Blank", "Duration", "")).isEmpty()
+    }
+
+    @Test
+    fun `ignores timers with an unknown type`() {
+        assertThat(validate("Timer_NoType", null, "whatever")).isEmpty()
+    }
+
+    private fun validate(id: String, type: String?, value: String?): List<ValidationViolation> {
+        val model = testBpmnModel(
+            flowNodes = listOf(
+                FlowNodeDefinition(
+                    id = id,
+                    properties = FlowNodeProperties.Timer(TimerDefinition(id = id, type = type, value = value)),
+                ),
+            ),
+        )
+        return underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+    }
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/TimerValueSyntaxTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/TimerValueSyntaxTest.kt
@@ -1,0 +1,50 @@
+package io.miragon.bpmn.domain.validation.rules
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TimerValueSyntaxTest {
+
+    @Test
+    fun `detects dynamic expressions`() {
+        assertThat(TimerValueSyntax.isExpression("=cronVar")).isTrue()
+        assertThat(TimerValueSyntax.isExpression("\${var}")).isTrue()
+        assertThat(TimerValueSyntax.isExpression("#{var}")).isTrue()
+        assertThat(TimerValueSyntax.isExpression("PT15M")).isFalse()
+    }
+
+    @Test
+    fun `accepts valid cron and rejects invalid cron`() {
+        assertThat(TimerValueSyntax.isValidCron("0 0 9 ? * MON-FRI")).isTrue()
+        assertThat(TimerValueSyntax.isValidCron("0 0 9 * * ? 2026")).isTrue()
+        assertThat(TimerValueSyntax.isValidCron("not a cron")).isFalse()
+        assertThat(TimerValueSyntax.isValidCron("0 0 9 * *")).isFalse()
+        assertThat(TimerValueSyntax.isValidCron("")).isFalse()
+    }
+
+    @Test
+    fun `accepts valid iso durations and rejects invalid ones`() {
+        assertThat(TimerValueSyntax.isValidIsoDuration("PT15M")).isTrue()
+        assertThat(TimerValueSyntax.isValidIsoDuration("P1Y2M")).isTrue()
+        assertThat(TimerValueSyntax.isValidIsoDuration("P1DT12H")).isTrue()
+        assertThat(TimerValueSyntax.isValidIsoDuration("15 minutes")).isFalse()
+        assertThat(TimerValueSyntax.isValidIsoDuration("R3/PT10M")).isFalse()
+    }
+
+    @Test
+    fun `accepts valid iso date-times and rejects invalid ones`() {
+        assertThat(TimerValueSyntax.isValidIsoDateTime("2026-01-01T00:00:00Z")).isTrue()
+        assertThat(TimerValueSyntax.isValidIsoDateTime("2026-01-01T00:00:00")).isTrue()
+        assertThat(TimerValueSyntax.isValidIsoDateTime("01/01/2026")).isFalse()
+        assertThat(TimerValueSyntax.isValidIsoDateTime("not-a-date")).isFalse()
+    }
+
+    @Test
+    fun `accepts valid iso repeating intervals and rejects invalid ones`() {
+        assertThat(TimerValueSyntax.isValidIsoRepeatingInterval("R3/PT10M")).isTrue()
+        assertThat(TimerValueSyntax.isValidIsoRepeatingInterval("R/PT1H")).isTrue()
+        assertThat(TimerValueSyntax.isValidIsoRepeatingInterval("R5/2026-01-01T00:00:00Z/PT1H")).isTrue()
+        assertThat(TimerValueSyntax.isValidIsoRepeatingInterval("PT10M")).isFalse()
+        assertThat(TimerValueSyntax.isValidIsoRepeatingInterval("0 0 9 * * ?")).isFalse()
+    }
+}

--- a/bpmn-to-code-testing/src/main/kotlin/io/miragon/bpmn/testing/BpmnRules.kt
+++ b/bpmn-to-code-testing/src/main/kotlin/io/miragon/bpmn/testing/BpmnRules.kt
@@ -12,6 +12,8 @@ import io.miragon.bpmn.domain.validation.rules.MissingProcessIdRule
 import io.miragon.bpmn.domain.validation.rules.MissingServiceTaskImplementationRule
 import io.miragon.bpmn.domain.validation.rules.MissingSignalNameRule
 import io.miragon.bpmn.domain.validation.rules.MissingTimerDefinitionRule
+import io.miragon.bpmn.domain.validation.rules.TimerCronSyntaxRule
+import io.miragon.bpmn.domain.validation.rules.TimerIso8601SyntaxRule
 
 /**
  * Provides access to all built-in BPMN validation rules.
@@ -99,8 +101,27 @@ object BpmnRules {
     @JvmField
     val COLLISION_DETECTION: BpmnValidationRule = CollisionDetectionRule()
 
+    // --- Optional rules (opt-in) ------------------------------------------------------------------
+    // Not part of [all]. Enable explicitly via BpmnValidator.withRules(...) to enforce a timer-format
+    // convention. Cron and ISO are mutually exclusive for timeCycle timers, so enable one of the two.
+
     /**
-     * Returns all built-in BPMN validation rules.
+     * Opt-in: enforces that `timeCycle` timers use a valid cron expression. Not part of [all].
+     */
+    @JvmField
+    val TIMER_CRON_SYNTAX: BpmnValidationRule = TimerCronSyntaxRule()
+
+    /**
+     * Opt-in: enforces that timer values are valid ISO-8601 for their type
+     * (Date -> date/time, Duration -> duration, Cycle -> repeating interval). Not part of [all].
+     */
+    @JvmField
+    val TIMER_ISO8601_SYNTAX: BpmnValidationRule = TimerIso8601SyntaxRule()
+
+    /**
+     * Returns all built-in BPMN validation rules that are enabled by default.
+     * Opt-in rules such as [TIMER_CRON_SYNTAX] and [TIMER_ISO8601_SYNTAX] are not included — add them
+     * explicitly via [BpmnValidator.withRules].
      */
     @JvmStatic
     fun all(): List<BpmnValidationRule> {

--- a/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/BpmnRulesTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/BpmnRulesTest.kt
@@ -49,4 +49,18 @@ class BpmnRulesTest {
             BpmnRules.COLLISION_DETECTION,
         )
     }
+
+    @Test
+    fun `optional rules are not part of all()`() {
+        assertThat(BpmnRules.all()).doesNotContain(
+            BpmnRules.TIMER_CRON_SYNTAX,
+            BpmnRules.TIMER_ISO8601_SYNTAX,
+        )
+    }
+
+    @Test
+    fun `optional rule constants have the expected ids`() {
+        assertThat(BpmnRules.TIMER_CRON_SYNTAX.id).isEqualTo("timer-cron-syntax")
+        assertThat(BpmnRules.TIMER_ISO8601_SYNTAX.id).isEqualTo("timer-iso8601-syntax")
+    }
 }

--- a/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/TimerSyntaxRuleTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/TimerSyntaxRuleTest.kt
@@ -1,0 +1,37 @@
+package io.miragon.bpmn.testing
+
+import io.miragon.bpmn.domain.shared.ProcessEngine
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TimerSyntaxRuleTest {
+
+    @Test
+    fun `cron rule flags only the invalid cron cycle`() {
+        val result = BpmnValidator
+            .fromClasspath("bpmn/timer-syntax.bpmn")
+            .engine(ProcessEngine.CAMUNDA_7)
+            .withRules(BpmnRules.TIMER_CRON_SYNTAX)
+            .validate()
+            .result()
+
+        assertThat(result.violations).hasSize(1)
+        assertThat(result.violations.single().elementId).isEqualTo("Timer_BadCron")
+    }
+
+    @Test
+    fun `iso rule validates by type and skips expressions`() {
+        val result = BpmnValidator
+            .fromClasspath("bpmn/timer-syntax.bpmn")
+            .engine(ProcessEngine.CAMUNDA_7)
+            .withRules(BpmnRules.TIMER_ISO8601_SYNTAX)
+            .validate()
+            .result()
+
+        val flagged = result.violations.map { it.elementId }
+        // Both cron cycles are not valid ISO repeating intervals:
+        assertThat(flagged).containsExactlyInAnyOrder("Timer_BadCron", "Timer_GoodCron")
+        // Valid ISO duration/date are accepted; the dynamic expression is skipped:
+        assertThat(flagged).doesNotContain("Timer_Duration", "Timer_Date", "Timer_FeelExpr")
+    }
+}

--- a/bpmn-to-code-testing/src/test/resources/bpmn/timer-syntax.bpmn
+++ b/bpmn-to-code-testing/src/test/resources/bpmn/timer-syntax.bpmn
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  id="Definitions_TimerSyntax"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="timerSyntaxProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="Timer_BadCron" name="Bad cron">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">not a cron</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Timer_GoodCron" name="Good cron">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9 ? * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Timer_Duration" name="Duration">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15M</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Timer_Date" name="Date">
+      <bpmn:incoming>Flow_4</bpmn:incoming>
+      <bpmn:outgoing>Flow_5</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2026-01-01T00:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Timer_FeelExpr" name="Expression">
+      <bpmn:incoming>Flow_5</bpmn:incoming>
+      <bpmn:outgoing>Flow_6</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">${dynamicDuration}</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_6</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Timer_BadCron" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Timer_BadCron" targetRef="Timer_GoodCron" />
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="Timer_GoodCron" targetRef="Timer_Duration" />
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="Timer_Duration" targetRef="Timer_Date" />
+    <bpmn:sequenceFlow id="Flow_5" sourceRef="Timer_Date" targetRef="Timer_FeelExpr" />
+    <bpmn:sequenceFlow id="Flow_6" sourceRef="Timer_FeelExpr" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="timerSyntaxProcess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Timer_BadCron_di" bpmnElement="Timer_BadCron">
+        <dc:Bounds x="252" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Timer_GoodCron_di" bpmnElement="Timer_GoodCron">
+        <dc:Bounds x="352" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Timer_Duration_di" bpmnElement="Timer_Duration">
+        <dc:Bounds x="452" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Timer_Date_di" bpmnElement="Timer_Date">
+        <dc:Bounds x="552" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Timer_FeelExpr_di" bpmnElement="Timer_FeelExpr">
+        <dc:Bounds x="652" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="752" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="188" y="100" />
+        <di:waypoint x="252" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="288" y="100" />
+        <di:waypoint x="352" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="388" y="100" />
+        <di:waypoint x="452" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_4_di" bpmnElement="Flow_4">
+        <di:waypoint x="488" y="100" />
+        <di:waypoint x="552" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_5_di" bpmnElement="Flow_5">
+        <di:waypoint x="588" y="100" />
+        <di:waypoint x="652" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_6_di" bpmnElement="Flow_6">
+        <di:waypoint x="688" y="100" />
+        <di:waypoint x="752" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/docs/validate/testing.md
+++ b/docs/validate/testing.md
@@ -132,6 +132,26 @@ result.assertNoViolations("invalid-identifier")  // custom: this rule is allowed
 | Element ID produces invalid identifier | `INVALID_IDENTIFIER` | WARN | ID that cannot be converted to valid UPPER_SNAKE_CASE |
 | Variable name collision | `COLLISION_DETECTION` | ERROR | Two different IDs normalize to the same constant name |
 
+## Optional Rules (opt-in)
+
+These rules are **not** part of `BpmnRules.all()` — they are off by default. Enable them explicitly via `withRules(...)` when you want to enforce a timer-format convention. They report as `ERROR` when enabled.
+
+| Rule | `BpmnRules` constant | Severity | Trigger |
+|------|---------------------|----------|---------|
+| Timer cycle is not valid cron | `TIMER_CRON_SYNTAX` | ERROR | A `timeCycle` timer whose value is not a valid cron expression |
+| Timer value is not valid ISO-8601 | `TIMER_ISO8601_SYNTAX` | ERROR | A timer value that is not valid ISO-8601 for its type (Date → date/time, Duration → duration, Cycle → repeating interval) |
+
+```kotlin
+BpmnValidator
+    .fromClasspath("bpmn/")
+    .engine(ProcessEngine.ZEEBE)
+    .withRules(*BpmnRules.all().toTypedArray(), BpmnRules.TIMER_CRON_SYNTAX)
+    .validate()
+    .assertNoViolations()
+```
+
+Cron and ISO-8601 are mutually exclusive for `timeCycle` timers, so enable **one** of the two depending on your scheduling convention. Dynamic timer expressions (Camunda `${...}`, Zeebe FEEL `=...`) are skipped, since their value is only known at runtime.
+
 ## Writing Custom Rules
 
 Implement the `BpmnValidationRule` interface to add project-specific checks:


### PR DESCRIPTION
## Summary

Adds two **opt-in** validation rules to `bpmn-to-code-testing` that validate timer-definition syntax:

- `timer-cron-syntax` — a `timeCycle` timer must be a valid cron expression (Cycle timers only).
- `timer-iso8601-syntax` — a timer value must be valid ISO-8601 for its type (Date → date/time, Duration → duration, Cycle → repeating interval).

Both are **ERROR** severity and **off by default** (not part of `BpmnRules.all()`), exposed as `BpmnRules` constants and enabled explicitly. Dynamic expressions (Camunda `${...}`, Zeebe FEEL `=...`) and blank values are skipped. The cron check is self-contained (no new dependency on `bpmn-to-code-core`); ISO validation uses JDK parsers (`java.time`, `javax.xml.datatype`).

## Enabling

```kotlin
BpmnValidator.fromClasspath("bpmn/").engine(ProcessEngine.ZEEBE)
    .withRules(*BpmnRules.all().toTypedArray(), BpmnRules.TIMER_CRON_SYNTAX)
    .validate()
```

Cron and ISO-8601 are mutually exclusive for `timeCycle` timers, so enable **one** of the two per convention. Non-Cycle timers stay out of the cron rule's scope (a `PT15M` timeout is legitimately not cron).

## Tests & docs

- Unit tests for both rules and the shared syntax helper; registry tests assert the rules stay out of `all()`; an end-to-end test over a new `timer-syntax.bpmn` fixture confirms behaviour through the parser.
- Documented in `docs/validate/testing.md` → "Optional Rules (opt-in)".

## Scope

Timer rules only (#4). The API-drift detection idea (#5) is tracked separately and is **not** part of this PR, despite the branch name.

Closes #4
