### PR TITLE
ci: add bpmnlint quality gate for BPMN models

### DIFF
--- a/.github/workflows/lint-bpmn-models.yml
+++ b/.github/workflows/lint-bpmn-models.yml
@@ -48,9 +48,8 @@ jobs:
           echo "Total: $(find ../shared/bpmn ../bpmn-to-code-web/src/main/resources/samples -name '*.bpmn' | wc -l | tr -d ' ') model(s)"
           npm run lint:bpmn
 
-      # Step 6: Lint testing-module fixtures with DI-only rules. They are
-      # intentionally semantically invalid in places, so only the
-      # diagram-interchange aspect (shapes present, no overlaps) is enforced.
+      # Step 6: Lint testing-module fixtures with DI-only rules 
+      # (relevant for models with bpmn-to-code-testing scope)
       - name: Lint BPMN testing fixtures (DI only)
         working-directory: tools
         run: |

--- a/.github/workflows/lint-bpmn-models.yml
+++ b/.github/workflows/lint-bpmn-models.yml
@@ -1,0 +1,49 @@
+name: Lint BPMN models
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**/*.bpmn'
+      - 'tools/**'
+      - '.github/workflows/lint-bpmn-models.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-bpmn:
+    name: Lint BPMN models
+    runs-on: ubuntu-24.04
+
+    steps:
+      # Step 1: Checkout code
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      # Step 2: Fail the build if any npm dependency is not pinned to an exact version
+      - name: Verify Pinned Dependencies
+        uses: miragon/pin-npm-dependencies@v1
+
+      # Step 3: Set up Node.js (npm tooling lives in tools/)
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: tools/package-lock.json
+
+      # Step 4: Install dependencies (bpmnlint)
+      - name: Install Dependencies
+        working-directory: tools
+        run: npm ci
+
+      # Step 5: Lint BPMN models (fails the build on any error)
+      - name: Lint BPMN models
+        working-directory: tools
+        run: |
+          echo "BPMN models under test:"
+          find ../shared/bpmn ../bpmn-to-code-web/src/main/resources/samples -name '*.bpmn'
+          echo "Total: $(find ../shared/bpmn ../bpmn-to-code-web/src/main/resources/samples -name '*.bpmn' | wc -l | tr -d ' ') model(s)"
+          npm run lint:bpmn

--- a/.github/workflows/lint-bpmn-models.yml
+++ b/.github/workflows/lint-bpmn-models.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: tools
         run: npm ci
 
-      # Step 5: Lint BPMN models (fails the build on any error)
+      # Step 5: Lint shipped models with the full rule set (fails on any error)
       - name: Lint BPMN models
         working-directory: tools
         run: |
@@ -47,3 +47,13 @@ jobs:
           find ../shared/bpmn ../bpmn-to-code-web/src/main/resources/samples -name '*.bpmn'
           echo "Total: $(find ../shared/bpmn ../bpmn-to-code-web/src/main/resources/samples -name '*.bpmn' | wc -l | tr -d ' ') model(s)"
           npm run lint:bpmn
+
+      # Step 6: Lint testing-module fixtures with DI-only rules. They are
+      # intentionally semantically invalid in places, so only the
+      # diagram-interchange aspect (shapes present, no overlaps) is enforced.
+      - name: Lint BPMN testing fixtures (DI only)
+        working-directory: tools
+        run: |
+          echo "BPMN testing fixtures under DI check:"
+          find ../bpmn-to-code-testing/src/test/resources/bpmn -name '*.bpmn'
+          npm run lint:bpmn:di

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ target
 .claude/logs/
 .claude/scheduled_tasks.lock
 docs/node_modules
+tools/node_modules
 docs/.vitepress/dist
 docs/.vitepress/cache
 .gstack/

--- a/bpmn-to-code-testing/src/test/resources/bpmn/invalid-process.bpmn
+++ b/bpmn-to-code-testing/src/test/resources/bpmn/invalid-process.bpmn
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
                   xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
                   id="Definitions_2"
                   targetNamespace="http://bpmn.io/schema/bpmn">
   <bpmn:message id="Message_1" />
@@ -24,4 +27,32 @@
     <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_NoImpl" targetRef="Event_Message" />
     <bpmn:sequenceFlow id="Flow_3" sourceRef="Event_Message" targetRef="EndEvent_1" />
   </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="invalidProcess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_NoImpl_di" bpmnElement="Task_NoImpl">
+        <dc:Bounds x="240" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_Message_di" bpmnElement="Event_Message">
+        <dc:Bounds x="392" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="480" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="188" y="100" />
+        <di:waypoint x="240" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="340" y="100" />
+        <di:waypoint x="392" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="428" y="100" />
+        <di:waypoint x="480" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/bpmn-to-code-testing/src/test/resources/bpmn/output-mapping-process.bpmn
+++ b/bpmn-to-code-testing/src/test/resources/bpmn/output-mapping-process.bpmn
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
                   xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
                   id="Definitions_1"
                   targetNamespace="http://bpmn.io/schema/bpmn">
   <bpmn:process id="outputMappingProcess" isExecutable="true">
@@ -23,4 +26,25 @@
     <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_DoWork" />
     <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_DoWork" targetRef="EndEvent_1" />
   </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="outputMappingProcess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_DoWork_di" bpmnElement="Task_DoWork">
+        <dc:Bounds x="240" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="392" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="188" y="100" />
+        <di:waypoint x="240" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="340" y="100" />
+        <di:waypoint x="392" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/bpmn-to-code-testing/src/test/resources/bpmn/valid-process.bpmn
+++ b/bpmn-to-code-testing/src/test/resources/bpmn/valid-process.bpmn
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
                   xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
                   id="Definitions_1"
                   targetNamespace="http://bpmn.io/schema/bpmn">
   <bpmn:process id="validProcess" isExecutable="true">
@@ -17,4 +20,25 @@
     <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_DoWork" />
     <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_DoWork" targetRef="EndEvent_1" />
   </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="validProcess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_DoWork_di" bpmnElement="Task_DoWork">
+        <dc:Bounds x="240" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="392" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="188" y="100" />
+        <di:waypoint x="240" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="340" y="100" />
+        <di:waypoint x="392" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/shared/bpmn/c7-additional-variables.bpmn
+++ b/shared/bpmn/c7-additional-variables.bpmn
@@ -41,7 +41,7 @@
         <bpmn:outgoing>Flow_3</bpmn:outgoing>
         <bpmn:messageEventDefinition messageRef="Message_2" />
       </bpmn:startEvent>
-      <bpmn:endEvent id="EndEvent_Cancelled">
+      <bpmn:endEvent id="EndEvent_Cancelled" name="Order cancelled">
         <bpmn:incoming>Flow_3</bpmn:incoming>
       </bpmn:endEvent>
       <bpmn:sequenceFlow id="Flow_3" sourceRef="StartEvent_OrderCancelled" targetRef="EndEvent_Cancelled" />

--- a/shared/bpmn/operaton-additional-variables.bpmn
+++ b/shared/bpmn/operaton-additional-variables.bpmn
@@ -41,7 +41,7 @@
         <bpmn:outgoing>Flow_3</bpmn:outgoing>
         <bpmn:messageEventDefinition messageRef="Message_2" />
       </bpmn:startEvent>
-      <bpmn:endEvent id="EndEvent_Cancelled">
+      <bpmn:endEvent id="EndEvent_Cancelled" name="Order cancelled">
         <bpmn:incoming>Flow_3</bpmn:incoming>
       </bpmn:endEvent>
       <bpmn:sequenceFlow id="Flow_3" sourceRef="StartEvent_OrderCancelled" targetRef="EndEvent_Cancelled" />

--- a/tools/.bpmnlintrc
+++ b/tools/.bpmnlintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "bpmnlint:recommended"
+}

--- a/tools/.bpmnlintrc-di
+++ b/tools/.bpmnlintrc-di
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "no-bpmndi": "error",
+    "no-overlapping-elements": "error"
+  }
+}

--- a/tools/README.md
+++ b/tools/README.md
@@ -3,14 +3,14 @@
 BPMN linting via [bpmnlint](https://github.com/bpmn-io/bpmnlint).
 
 ```bash
-npm --prefix tools install   # one-time
+npm --prefix tools install
 ```
 
 ## Full linting
 
-Production-grade check: the full `bpmnlint:recommended` rule set (`.bpmnlintrc`)
-over the models we ship — `shared/bpmn/*.bpmn` and the web module's bundled
-samples.
+This runs the full `bpmnlint:recommended` rule set from `.bpmnlintrc`,
+over the models we ship in production.
+Those are the models under `shared/bpmn` and the bundled samples of the web module.
 
 ```bash
 npm --prefix tools run lint:bpmn
@@ -18,11 +18,13 @@ npm --prefix tools run lint:bpmn
 
 ## Reduced linting
 
-Only the diagram-interchange rules (`.bpmnlintrc-di`: `no-bpmndi`,
-`no-overlapping-elements`) over the `bpmn-to-code-testing` fixtures. Those
-fixtures are intentionally semantically invalid in places, so the full rule set
-does not fit — this just ensures they are visually valid (every element has a
-shape, nothing overlaps).
+This runs only the diagram interchange rules from `.bpmnlintrc-di`,
+namely `no-bpmndi` and `no-overlapping-elements`,
+over the fixtures of `bpmn-to-code-testing`.
+Those fixtures are intentionally invalid in places,
+so the full rule set does not fit.
+The reduced check only makes sure they are valid in a visual manner,
+which means every element has a shape and nothing overlaps.
 
 ```bash
 npm --prefix tools run lint:bpmn:di
@@ -30,6 +32,6 @@ npm --prefix tools run lint:bpmn:di
 
 ## Pipeline
 
-Both checks run in CI via `.github/workflows/lint-bpmn-models.yml` on every pull
-request that touches a `.bpmn` file or `tools/`, so models are validated before
-they are merged to `main`.
+Both checks run in CI through `.github/workflows/lint-bpmn-models.yml`,
+on every pull request that touches a `.bpmn` file or the `tools` folder.
+This ensures the models are validated before they are merged to `main`.

--- a/tools/README.md
+++ b/tools/README.md
@@ -3,16 +3,33 @@
 BPMN linting via [bpmnlint](https://github.com/bpmn-io/bpmnlint).
 
 ```bash
-npm --prefix tools install        # one-time
-npm --prefix tools run lint:bpmn      # full rules on shipped models
-npm --prefix tools run lint:bpmn:di   # DI-only rules on testing fixtures
+npm --prefix tools install   # one-time
 ```
 
-- `lint:bpmn` — `bpmnlint:recommended` (`.bpmnlintrc`) over `shared/bpmn/*.bpmn`
-  and the web module's bundled samples.
-- `lint:bpmn:di` — only the diagram-interchange rules (`.bpmnlintrc-di`:
-  `no-bpmndi`, `no-overlapping-elements`) over the `bpmn-to-code-testing`
-  fixtures. Those fixtures are intentionally semantically invalid in places, so
-  they get the DI check only — not the full rule set.
+## Full linting
 
-Both run in CI via `.github/workflows/lint-bpmn-models.yml`.
+Production-grade check: the full `bpmnlint:recommended` rule set (`.bpmnlintrc`)
+over the models we ship — `shared/bpmn/*.bpmn` and the web module's bundled
+samples.
+
+```bash
+npm --prefix tools run lint:bpmn
+```
+
+## Reduced linting
+
+Only the diagram-interchange rules (`.bpmnlintrc-di`: `no-bpmndi`,
+`no-overlapping-elements`) over the `bpmn-to-code-testing` fixtures. Those
+fixtures are intentionally semantically invalid in places, so the full rule set
+does not fit — this just ensures they are visually valid (every element has a
+shape, nothing overlaps).
+
+```bash
+npm --prefix tools run lint:bpmn:di
+```
+
+## Pipeline
+
+Both checks run in CI via `.github/workflows/lint-bpmn-models.yml` on every pull
+request that touches a `.bpmn` file or `tools/`, so models are validated before
+they are merged to `main`.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,18 @@
+# tools
+
+BPMN linting via [bpmnlint](https://github.com/bpmn-io/bpmnlint).
+
+```bash
+npm --prefix tools install        # one-time
+npm --prefix tools run lint:bpmn      # full rules on shipped models
+npm --prefix tools run lint:bpmn:di   # DI-only rules on testing fixtures
+```
+
+- `lint:bpmn` — `bpmnlint:recommended` (`.bpmnlintrc`) over `shared/bpmn/*.bpmn`
+  and the web module's bundled samples.
+- `lint:bpmn:di` — only the diagram-interchange rules (`.bpmnlintrc-di`:
+  `no-bpmndi`, `no-overlapping-elements`) over the `bpmn-to-code-testing`
+  fixtures. Those fixtures are intentionally semantically invalid in places, so
+  they get the DI check only — not the full rule set.
+
+Both run in CI via `.github/workflows/lint-bpmn-models.yml`.

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -1,0 +1,203 @@
+{
+  "name": "bpmn-to-code-tooling",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bpmn-to-code-tooling",
+      "version": "1.0.0",
+      "devDependencies": {
+        "bpmnlint": "11.12.1"
+      }
+    },
+    "node_modules/@bpmn-io/moddle-utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/moddle-utils/-/moddle-utils-0.3.0.tgz",
+      "integrity": "sha512-0kz2PKfjIH3XFtO9Koxh7jV8e1DWWs4rgp0IczhJgluoRHf9Jhq8zX1H3wGJu6+lpg1Rkzc6YW1ezKz+2K8wTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^5.0.0"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/bpmn-moddle": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-10.0.0.tgz",
+      "integrity": "sha512-vXePD5jkatcILmM3zwJG/m6IIHIghTGB7WvgcdEraEw8E8VdJHrTgrvBUhbzqaXJpnsGQz15QS936xeBY6l9aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^5.0.0",
+        "moddle": "^8.0.0",
+        "moddle-xml": "^12.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12"
+      }
+    },
+    "node_modules/bpmnlint": {
+      "version": "11.12.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-11.12.1.tgz",
+      "integrity": "sha512-s/V68yzJU/ko7ea6ljp/xUUC8PUN+fzZaqI+votu0DPzDc6OqvpBcKzw7rMpqS4WPw/HOW3cLw/C2poWilClCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/moddle-utils": "^0.3.0",
+        "ansi-colors": "^4.1.3",
+        "bpmn-moddle": "^10.0.0",
+        "bpmnlint-utils": "^1.1.1",
+        "cli-table": "^0.3.11",
+        "color-support": "^1.1.3",
+        "min-dash": "^5.0.0",
+        "mri": "^1.2.0",
+        "pluralize": "^8.0.0",
+        "tiny-glob": "^0.2.9"
+      },
+      "bin": {
+        "bpmnlint": "bin/bpmnlint.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/bpmnlint-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint-utils/-/bpmnlint-utils-1.1.1.tgz",
+      "integrity": "sha512-Afdb77FmwNB3INyUfbzXW40yY+mc0qYU3SgDFeI4zTtduiVomOlfqoXiEaUIGI8Hyh7aVYpmf3O97P2w7x0DYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "dev": true,
+      "dependencies": {
+        "colors": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/min-dash": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
+      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/moddle": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/moddle/-/moddle-8.1.0.tgz",
+      "integrity": "sha512-dBddc1CNuZHgro8nQWwfPZ2BkyLWdnxoNpPu9d+XKPN96DAiiBOeBw527ft++ebDuFez5PMdaR3pgUgoOaUGrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^5.0.0"
+      }
+    },
+    "node_modules/moddle-xml": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-12.0.0.tgz",
+      "integrity": "sha512-NJc2+sCe4tvuGlaUBcoZcYf6j9f+z+qxHOyGm/LB3ZrlJXVPPHoBTg/KXgDRCufdBJhJ3AheFs3QU/abABNzRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^5.0.0",
+        "saxen": "^11.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "moddle": ">= 6.2.0"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/saxen": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-11.0.2.tgz",
+      "integrity": "sha512-WDb4gqac8uiJzOdOdVpr9NWh9NrJMm7Brn5GX2Poj+mjE/QTXqYQENr8T/mom54dDDgbd3QjwTg23TRHYiWXRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.12"
+      }
+    },
+    "node_modules/tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
+    }
+  }
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bpmn-to-code-tooling",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Dev tooling for bpmn-to-code: BPMN linting via bpmnlint.",
+  "scripts": {
+    "lint:bpmn": "bpmnlint \"../shared/bpmn/*.bpmn\" \"../bpmn-to-code-web/src/main/resources/samples/*.bpmn\""
+  },
+  "devDependencies": {
+    "bpmnlint": "11.12.1"
+  }
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "description": "Dev tooling for bpmn-to-code: BPMN linting via bpmnlint.",
   "scripts": {
-    "lint:bpmn": "bpmnlint \"../shared/bpmn/*.bpmn\" \"../bpmn-to-code-web/src/main/resources/samples/*.bpmn\""
+    "lint:bpmn": "bpmnlint \"../shared/bpmn/*.bpmn\" \"../bpmn-to-code-web/src/main/resources/samples/*.bpmn\"",
+    "lint:bpmn:di": "bpmnlint -c .bpmnlintrc-di \"../bpmn-to-code-testing/src/test/resources/bpmn/*.bpmn\""
   },
   "devDependencies": {
     "bpmnlint": "11.12.1"


### PR DESCRIPTION
## What

Adds a BPMN linting quality gate, adapted from the [easy-zeebe](https://github.com/emaarco/easy-zeebe) approach — a minimal bpmnlint integration using bpmn.io's own rules (no custom rules).

- **`tools/`** — small npm workspace with `bpmnlint` (pinned `11.12.1`) and `.bpmnlintrc` extending `bpmnlint:recommended`. Lints `shared/bpmn/*.bpmn` and the web module's bundled samples.
- **`.github/workflows/lint-bpmn-models.yml`** — runs on PRs touching any `.bpmn` file or `tools/`. Verifies pinned npm deps, then `npm ci` + `npm run lint:bpmn`. Fails only on lint **errors**.
- **Model fixes** — the cancelled end event in `c7-additional-variables` and `operaton-additional-variables` had no name (`label-required` error); named both "Order cancelled".
- **Testing-module fixtures** — `valid`/`invalid`/`output-mapping` carried no diagram interchange. Added horizontal-layout DI to all three. `invalid-process` stays semantically invalid (its service task still has no implementation, message still unnamed).

## Why

Guarantees every BPMN model shipped in the repo is parseable and follows a baseline of bpmn.io conventions. The testing fixtures now also carry DI, which a well-formed model should have.

## Notes

- Testing-module fixtures are intentionally **not** in the lint scope — they're hand-crafted unit-test inputs (one deliberately invalid).
- `bpmn-to-code-testing` and `bpmn-to-code-core` test suites pass with all changes.
- Remaining lint output is 6 non-blocking `warning`s (`fake-join`, unused-message `global`) that `bpmnlint:recommended` itself classifies as warnings; left as-is to avoid restructuring demo models.