### PR TITLE
chore(release): use client-id for create-github-app-token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/create-github-app-token@v2
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
       - id: rp
         uses: googleapis/release-please-action@v5

--- a/.github/workflows/update-ops-deployment.yml
+++ b/.github/workflows/update-ops-deployment.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/create-github-app-token@v2
         id: ops-token
         with:
-          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
           owner: Miragon
           repositories: ops


### PR DESCRIPTION
The `app-id` input of `actions/create-github-app-token` is deprecated in favor of `client-id`, which expects the GitHub App's **Client ID** (e.g. `Iv23li…`) — a different value than the numeric App ID.

This switches the app-token steps in both `release-please.yml` and `update-ops-deployment.yml` to `client-id`, sourced from the org-level variable `RELEASE_PLEASE_APP_CLIENT_ID` (the release-please App's Client ID). The private-key secret `RELEASE_PLEASE_APP_PRIVATE_KEY` is unchanged.

The same change was already applied in `Miragon/bpmn-modeler` (#1201).

> [!NOTE]
> This requires the org variable `RELEASE_PLEASE_APP_CLIENT_ID` to be visible to this repository. If that variable is scoped to selected repositories, add this repo to its list before merging, otherwise the token step will fail.
