### PR TITLE
chore(ci): rely on CODEOWNERS for Dependabot review routing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,8 +37,6 @@ updates:
       interval: "monthly"
     labels:
       - "dependencies"
-    assignees:
-      - "emaarco"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## What
Remove the `assignees: emaarco` entry from the `github-actions` block in `.github/dependabot.yml`.

## Why
`.github/CODEOWNERS` (`* @emaarco`) already auto-requests review on every PR, including all Dependabot ecosystems. The explicit `assignees` on just one of the three blocks was redundant and inconsistent. Review routing is now handled uniformly by CODEOWNERS; the `dependencies` label is retained for filtering.