### PR TITLE
feat(core): skip non-executable BPMN processes

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
@@ -16,6 +16,7 @@ import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSign
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findTimerEventDefinition
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.extractVariantName
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.getProcessId
+import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.isExecutable
 import io.miragon.bpmn.domain.BpmnModel
 import io.miragon.bpmn.domain.shared.CallActivityDefinition
 import io.miragon.bpmn.domain.shared.CallActivityMapping
@@ -79,6 +80,7 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
             escalations = escalations,
             compensations = compensations,
             detectedEngine = EngineDetector.detect(bytes.decodeToString()),
+            isExecutable = modelInstance.isExecutable(),
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
@@ -16,6 +16,7 @@ import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSign
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findTimerEventDefinition
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.extractVariantName
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.getProcessId
+import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.isExecutable
 import io.miragon.bpmn.domain.BpmnModel
 import io.miragon.bpmn.domain.shared.CallActivityDefinition
 import io.miragon.bpmn.domain.shared.CallActivityMapping
@@ -83,6 +84,7 @@ class OperatonModelExtractor : EngineSpecificExtractor {
             escalations = escalations,
             compensations = compensations,
             detectedEngine = EngineDetector.detect(bytes.decodeToString()),
+            isExecutable = modelInstance.isExecutable(),
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
@@ -17,6 +17,7 @@ import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSign
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findTimerEventDefinition
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.extractVariantName
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.getProcessId
+import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.isExecutable
 import io.miragon.bpmn.domain.BpmnModel
 import io.miragon.bpmn.domain.shared.CallActivityDefinition
 import io.miragon.bpmn.domain.shared.CallActivityMapping
@@ -70,6 +71,7 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
             escalations = allEscalationEvents,
             compensations = allCompensationEvents,
             detectedEngine = EngineDetector.detect(bytes.decodeToString()),
+            isExecutable = modelInstance.isExecutable(),
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
@@ -39,6 +39,12 @@ object ModelInstanceUtils {
         return processId
     }
 
+    fun ModelInstance.isExecutable(): Boolean {
+        val process = this.findProcess()
+        val raw = process.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_IS_EXECUTABLE)
+        return raw?.toBoolean() ?: true
+    }
+
     fun ModelInstance.extractVariantName(): String? {
         val process = this.findProcess()
         val extensions = process.findExtensionElements()

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
@@ -30,6 +30,7 @@ import org.camunda.bpm.model.xml.ModelInstance
  * Utility functions for extracting BPMN elements that are common across process engines.
  * Use this only if you have a method that can be used by multiple extractors.
  */
+@Suppress("TooManyFunctions")
 object ModelInstanceUtils {
 
     fun ModelInstance.getProcessId(): String {

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/application/service/GenerateProcessApiService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/application/service/GenerateProcessApiService.kt
@@ -15,6 +15,9 @@ import io.miragon.bpmn.domain.ProcessModel
 import io.miragon.bpmn.domain.service.BpmnValidationService
 import io.miragon.bpmn.domain.service.ModelMergerService
 import io.miragon.bpmn.domain.validation.model.ValidationPhase
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
 
 class GenerateProcessApiService(
     private val codeGenerator: GenerateApiCodePort = CodeGenerationAdapter(),
@@ -28,7 +31,13 @@ class GenerateProcessApiService(
     override fun generateProcessApi(command: GenerateProcessApiFromFilesystemUseCase.Command): List<BpmnFileResult> {
         val validationService = BpmnValidationService(command.validationConfig)
         val inputFiles = bpmnFileLoader.loadFrom(command.baseDir, command.filePattern)
-        val models = inputFiles.map { bpmnService.extract(it, command.engine) }
+        val executable = inputFiles.map { it to bpmnService.extract(it, command.engine) }
+            .filter { (file, model) ->
+                val keep = model.isExecutable
+                if (!keep) logger.info { "Skipping '${model.processId}' (${file.fileName}): process is marked non-executable" }
+                keep
+            }
+        val models = executable.map { (_, model) -> model }
         validationService.validate(models, command.engine, ValidationPhase.PRE_MERGE)
         val mergedModels = modelMergerService.mergeModels(models)
         validationService.validate(mergedModels, command.engine, ValidationPhase.POST_MERGE)
@@ -36,7 +45,7 @@ class GenerateProcessApiService(
             .flatMap { codeGenerator.generateCode(toBpmnModelApi(it, command)) }
             .distinctBy { it.packagePath to it.fileName }
         fileSystemOutput.writeFiles(generatedFiles, command.outputFolderPath)
-        val filesByProcessId = inputFiles.zip(models)
+        val filesByProcessId = executable
             .groupBy({ (_, model) -> model.processId }, { (file, _) -> file.fileName })
         return mergedModels.map { model ->
             BpmnFileResult(

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/application/service/GenerateProcessApiService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/application/service/GenerateProcessApiService.kt
@@ -10,14 +10,14 @@ import io.miragon.bpmn.application.port.outbound.ExtractBpmnPort
 import io.miragon.bpmn.application.port.outbound.GenerateApiCodePort
 import io.miragon.bpmn.application.port.outbound.LoadBpmnFilesPort
 import io.miragon.bpmn.application.port.outbound.SaveProcessApiPort
+import io.miragon.bpmn.domain.BpmnModel
 import io.miragon.bpmn.domain.BpmnModelApi
+import io.miragon.bpmn.domain.BpmnResource
 import io.miragon.bpmn.domain.ProcessModel
 import io.miragon.bpmn.domain.service.BpmnValidationService
 import io.miragon.bpmn.domain.service.ModelMergerService
 import io.miragon.bpmn.domain.validation.model.ValidationPhase
 import io.github.oshai.kotlinlogging.KotlinLogging
-
-private val logger = KotlinLogging.logger {}
 
 class GenerateProcessApiService(
     private val codeGenerator: GenerateApiCodePort = CodeGenerationAdapter(),
@@ -26,18 +26,15 @@ class GenerateProcessApiService(
     private val fileSystemOutput: SaveProcessApiPort = ProcessApiFileSaver(),
 ) : GenerateProcessApiFromFilesystemUseCase {
 
+    private val logger = KotlinLogging.logger {}
     private val modelMergerService = ModelMergerService()
 
     override fun generateProcessApi(command: GenerateProcessApiFromFilesystemUseCase.Command): List<BpmnFileResult> {
         val validationService = BpmnValidationService(command.validationConfig)
         val inputFiles = bpmnFileLoader.loadFrom(command.baseDir, command.filePattern)
-        val executable = inputFiles.map { it to bpmnService.extract(it, command.engine) }
-            .filter { (file, model) ->
-                val keep = model.isExecutable
-                if (!keep) logger.info { "Skipping '${model.processId}' (${file.fileName}): process is marked non-executable" }
-                keep
-            }
-        val models = executable.map { (_, model) -> model }
+        val extractedModels = inputFiles.map { it to bpmnService.extract(it, command.engine) }
+        val executableModels = filterExecutableProcesses(extractedModels)
+        val models = executableModels.map { (_, model) -> model }
         validationService.validate(models, command.engine, ValidationPhase.PRE_MERGE)
         val mergedModels = modelMergerService.mergeModels(models)
         validationService.validate(mergedModels, command.engine, ValidationPhase.POST_MERGE)
@@ -45,13 +42,23 @@ class GenerateProcessApiService(
             .flatMap { codeGenerator.generateCode(toBpmnModelApi(it, command)) }
             .distinctBy { it.packagePath to it.fileName }
         fileSystemOutput.writeFiles(generatedFiles, command.outputFolderPath)
-        val filesByProcessId = executable
+        val filesByProcessId = executableModels
             .groupBy({ (_, model) -> model.processId }, { (file, _) -> file.fileName })
         return mergedModels.map { model ->
             BpmnFileResult(
                 processId = model.processId,
                 sourceFiles = filesByProcessId[model.processId] ?: emptyList(),
             )
+        }
+    }
+
+    private fun filterExecutableProcesses(
+        extractedModels: List<Pair<BpmnResource, BpmnModel>>,
+    ): List<Pair<BpmnResource, BpmnModel>> {
+        return extractedModels.filter { (file, model) ->
+            val keep = model.isExecutable
+            if (!keep) logger.info { "Skipping '${model.processId}' (${file.fileName}): process is marked non-executable" }
+            keep
         }
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/BpmnModel.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/BpmnModel.kt
@@ -25,6 +25,7 @@ data class BpmnModel(
     override val escalations: List<EscalationDefinition> = emptyList(),
     override val compensations: List<CompensationDefinition> = emptyList(),
     val detectedEngine: ProcessEngine? = null,
+    val isExecutable: Boolean = true,
 ) : ProcessModel {
     override val serviceTasks: List<ServiceTaskDefinition>
         get() = flowNodes.mapNotNull { (it.properties as? FlowNodeProperties.ServiceTask)?.definition }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -323,4 +323,25 @@ class Camunda7ModelExtractorTest {
         assertThat(callActivity.propagateAllInputVariables).isNull()
         assertThat(callActivity.propagateAllOutputVariables).isNull()
     }
+
+    @Test
+    fun `extract marks a process with isExecutable false as non-executable`() {
+        val file = File(requireNotNull(javaClass.getResource("/bpmn/c7-non-executable.bpmn")).toURI())
+        val bpmnModel = underTest.extract(file.readBytes())
+        assertThat(bpmnModel.isExecutable).isFalse()
+    }
+
+    @Test
+    fun `extract marks a process with isExecutable true as executable`() {
+        val file = File(requireNotNull(javaClass.getResource("/bpmn/c7-subscribe-newsletter.bpmn")).toURI())
+        val bpmnModel = underTest.extract(file.readBytes())
+        assertThat(bpmnModel.isExecutable).isTrue()
+    }
+
+    @Test
+    fun `extract treats an absent isExecutable attribute as executable`() {
+        val file = File(requireNotNull(javaClass.getResource("/bpmn/c7-no-executable-attr.bpmn")).toURI())
+        val bpmnModel = underTest.extract(file.readBytes())
+        assertThat(bpmnModel.isExecutable).isTrue()
+    }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -257,4 +257,18 @@ class OperatonModelExtractorTest {
         )
     }
 
+    @Test
+    fun `extract marks a process with isExecutable false as non-executable`() {
+        val file = File(requireNotNull(javaClass.getResource("/bpmn/operaton-non-executable.bpmn")).toURI())
+        val bpmnModel = underTest.extract(file.readBytes())
+        assertThat(bpmnModel.isExecutable).isFalse()
+    }
+
+    @Test
+    fun `extract marks a process with isExecutable true as executable`() {
+        val file = File(requireNotNull(javaClass.getResource("/bpmn/operaton-subscribe-newsletter.bpmn")).toURI())
+        val bpmnModel = underTest.extract(file.readBytes())
+        assertThat(bpmnModel.isExecutable).isTrue()
+    }
+
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -257,4 +257,18 @@ class ZeebeModelExtractorTest {
         assertThat(bpmnModel.detectedEngine).isEqualTo(ProcessEngine.CAMUNDA_7)
     }
 
+    @Test
+    fun `extract marks a process with isExecutable false as non-executable`() {
+        val file = File(requireNotNull(javaClass.getResource("/bpmn/c8-non-executable.bpmn")).toURI())
+        val bpmnModel = underTest.extract(file.readBytes())
+        assertThat(bpmnModel.isExecutable).isFalse()
+    }
+
+    @Test
+    fun `extract marks a process with isExecutable true as executable`() {
+        val file = File(requireNotNull(javaClass.getResource("/bpmn/c8-subscribe-newsletter.bpmn")).toURI())
+        val bpmnModel = underTest.extract(file.readBytes())
+        assertThat(bpmnModel.isExecutable).isTrue()
+    }
+
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/application/service/GenerateProcessApiServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/application/service/GenerateProcessApiServiceTest.kt
@@ -72,12 +72,92 @@ class GenerateProcessApiServiceTest {
         assertThat(results).isEqualTo(listOf(BpmnFileResult(processId = "newsletterSubscription", sourceFiles = listOf("dummy.bpmn"))))
     }
 
+    @Test
+    fun `generateProcessApi skips a non-executable process`() {
+
+        // given: a single non-executable model
+        val draftResource = BpmnResource(fileName = "draft.bpmn", content = "<bpmn></bpmn>".encodeToByteArray())
+        every { bpmnFileLoader.loadFrom("baseDir", "*.bpmn") } returns listOf(draftResource)
+        every { bpmnService.extract(any(), any()) } returns nonExecutableModel
+
+        // when: generateProcessApi is invoked
+        val results = underTest.generateProcessApi(command())
+
+        // then: nothing is generated, written or reported
+        assertThat(results).isEmpty()
+        verify(exactly = 0) { codeGenerator.generateCode(any()) }
+        verify { fileSystemOutput.writeFiles(emptyList(), "outputFolder") }
+    }
+
+    @Test
+    fun `generateProcessApi generates only the executable process when mixed`() {
+
+        // given: one executable and one non-executable model
+        val keepResource = BpmnResource(fileName = "keep.bpmn", content = "<bpmn></bpmn>".encodeToByteArray())
+        val draftResource = BpmnResource(fileName = "draft.bpmn", content = "<bpmn></bpmn>".encodeToByteArray())
+        val expectedGeneratedFile = GeneratedApiFile(
+            fileName = "NewsletterSubscriptionProcessApi.kt",
+            packagePath = "de.emaarco.example",
+            content = "// generated code",
+            language = OutputLanguage.KOTLIN,
+            processId = "newsletterSubscription",
+        )
+        every { bpmnFileLoader.loadFrom("baseDir", "*.bpmn") } returns listOf(keepResource, draftResource)
+        every { bpmnService.extract(keepResource, any()) } returns dummyModel
+        every { bpmnService.extract(draftResource, any()) } returns nonExecutableModel
+        every { codeGenerator.generateCode(any()) } returns listOf(expectedGeneratedFile)
+
+        // when: generateProcessApi is invoked
+        val results = underTest.generateProcessApi(command())
+
+        // then: only the executable process is generated and reported
+        verify(exactly = 1) { codeGenerator.generateCode(getExpectedModelApi()) }
+        verify { fileSystemOutput.writeFiles(listOf(expectedGeneratedFile), "outputFolder") }
+        assertThat(results).isEqualTo(listOf(BpmnFileResult(processId = "newsletterSubscription", sourceFiles = listOf("keep.bpmn"))))
+    }
+
+    @Test
+    fun `generateProcessApi produces no output when all processes are non-executable`() {
+
+        // given: only non-executable models
+        val draftOne = BpmnResource(fileName = "draft-1.bpmn", content = "<bpmn></bpmn>".encodeToByteArray())
+        val draftTwo = BpmnResource(fileName = "draft-2.bpmn", content = "<bpmn></bpmn>".encodeToByteArray())
+        every { bpmnFileLoader.loadFrom("baseDir", "*.bpmn") } returns listOf(draftOne, draftTwo)
+        every { bpmnService.extract(any(), any()) } returns nonExecutableModel
+
+        // when: generateProcessApi is invoked
+        val results = underTest.generateProcessApi(command())
+
+        // then: generation completes with no output and no crash
+        assertThat(results).isEmpty()
+        verify(exactly = 0) { codeGenerator.generateCode(any()) }
+        verify { fileSystemOutput.writeFiles(emptyList(), "outputFolder") }
+    }
+
     private val dummyModel = BpmnModel(
         processId = "newsletterSubscription",
         flowNodes = emptyList(),
         messages = emptyList(),
         signals = emptyList(),
         errors = emptyList(),
+    )
+
+    private val nonExecutableModel = BpmnModel(
+        processId = "draftProcess",
+        flowNodes = emptyList(),
+        messages = emptyList(),
+        signals = emptyList(),
+        errors = emptyList(),
+        isExecutable = false,
+    )
+
+    private fun command() = GenerateProcessApiFromFilesystemUseCase.Command(
+        baseDir = "baseDir",
+        filePattern = "*.bpmn",
+        engine = ProcessEngine.ZEEBE,
+        outputFolderPath = "outputFolder",
+        outputLanguage = OutputLanguage.KOTLIN,
+        packagePath = "de.emaarco.example",
     )
 
     private fun getExpectedModelApi() = testBpmnModelApi(

--- a/shared/bpmn/c7-no-executable-attr.bpmn
+++ b/shared/bpmn/c7-no-executable-attr.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  id="Definitions_c7_noattr"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="attributeAbsentProcess">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1" name="End">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="attributeAbsentProcess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="172" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="272" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="208" y="118" />
+        <di:waypoint x="272" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/shared/bpmn/c7-non-executable.bpmn
+++ b/shared/bpmn/c7-non-executable.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  id="Definitions_c7_nonexec"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="nonExecutableProcess" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1" name="End">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="nonExecutableProcess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="172" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="272" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="208" y="118" />
+        <di:waypoint x="272" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/shared/bpmn/c8-non-executable.bpmn
+++ b/shared/bpmn/c8-non-executable.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  id="Definitions_c8_nonexec"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="nonExecutableProcess" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1" name="End">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="nonExecutableProcess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="172" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="272" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="208" y="118" />
+        <di:waypoint x="272" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/shared/bpmn/operaton-non-executable.bpmn
+++ b/shared/bpmn/operaton-non-executable.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:operaton="http://operaton.org/schema/1.0/bpmn"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  id="Definitions_operaton_nonexec"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="nonExecutableProcess" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1" name="End">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="nonExecutableProcess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="172" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="272" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="208" y="118" />
+        <di:waypoint x="272" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Summary

Closes #14. BPMN processes explicitly marked `isExecutable="false"` no longer produce a generated Process API — non-executable models (documentation diagrams, drafts) stop polluting generated code.

- Read the `isExecutable` attribute in the shared extractor utility (`ModelInstanceUtils.isExecutable()`), carry it on `BpmnModel`, and filter it out in `GenerateProcessApiService` before validation/merge/generation. Each skip is logged at INFO.
- **Conservative default:** only skip when the attribute is present and `false`. If it is absent, behavior is unchanged (generate).
- Consistent across Camunda 7, Zeebe and Operaton.
- Scope: the filesystem Process API service only (the in-memory/web API and JSON generators are left as-is).

## Behavior

- `isExecutable="false"` → no generated API, logged skip, build does not fail.
- `isExecutable="true"` or attribute absent → generated as before.
- All matched files non-executable → completes with no output, no crash.

## Tests

- Extractor tests for all three engines: non-executable → `false`, executable → `true`, attribute-absent → `true`.
- Service tests: skipped / mixed / all-skipped scenarios.
- New fixtures under `shared/bpmn/` pass `bpmnlint` (`npm run lint:bpmn`, incl. DI).

Verified: `:bpmn-to-code-core:test`, `:bpmn-to-code-gradle:test`, `:bpmn-to-code-maven:test`, and `lint:bpmn` all green.