### PR TITLE
ci: request emaarco review on ops deployment PRs

### DIFF
--- a/.github/workflows/update-ops-deployment.yml
+++ b/.github/workflows/update-ops-deployment.yml
@@ -98,6 +98,7 @@ jobs:
           git commit -am "chore: bump bpmn-to-code-web to ${VERSION}"
           git push --force origin "$branch"
           gh pr create --base main --head "$branch" \
+            --reviewer emaarco \
             --title "chore: bump bpmn-to-code-web to ${VERSION}" \
             --body "Automated deployment bump triggered by the bpmn-to-code release pipeline.
 


### PR DESCRIPTION
Adds `--reviewer emaarco` to the `gh pr create` call in the *Update ops deployment* workflow so every auto-generated deployment-bump PR in `Miragon/ops` requests my review.

**Why:** ensures the person who should merge the bump always sees it in their review queue.