### PR TITLE
chore(conductor): add selectable run targets and disable autostart

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,23 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "npm --prefix docs ci"
+archive = "./gradlew --stop"
+run_mode = "nonconcurrent"
+
+[scripts.run.web]
+command = "./gradlew :bpmn-to-code-web:run"
+default = true
+icon = "globe"
+
+[scripts.run.docs]
+command = "npm --prefix docs run dev"
+icon = "book-open"
+
+[scripts.run.test]
+command = "./gradlew test"
+icon = "test-tube"
+
+[scripts.run.build]
+command = "./gradlew build"
+icon = "hammer"


### PR DESCRIPTION
## What

Replaces Conductor's single auto-starting Run script with a **menu of selectable run targets** and turns autostart off, so a new workspace opens quietly and the user picks what to run.

Adds `.conductor/settings.toml` with:

| Target | Command | Default |
|--------|---------|---------|
| **web** | `./gradlew :bpmn-to-code-web:run` | ✅ |
| **docs** | `npm --prefix docs run dev` | |
| **test** | `./gradlew test` | |
| **build** | `./gradlew build` | |

Plus lifecycle scripts:
- **setup** = `npm --prefix docs ci` — provisions docs deps (from the committed lockfile) once at workspace creation.
- **archive** = `./gradlew --stop` — stops the Gradle daemon on cleanup.

## Why `run_mode = "nonconcurrent"`

The web demo binds a fixed port (8080, hardcoded in `AppConfig`), so it isn't per-workspace isolated — concurrent runs across workspaces would clash.

## Note

`.conductor/settings.toml` is read from the default branch, so it only affects workspaces created **after** this merges to `main`.