### PR TITLE
test(core): add same-name input+output variable example across all engines

### DIFF
--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/codegen/builder/NewsletterFlowNodes.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/codegen/builder/NewsletterFlowNodes.kt
@@ -46,7 +46,10 @@ internal fun buildSubscribeNewsletterFlowNodes(
         id = "Activity_SendWelcomeMail",
         elementType = BpmnElementType.SERVICE_TASK,
         properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition("Activity_SendWelcomeMail", engineSpecificProperties = mapOf(IMPL_VALUE_KEY to welcomeMailImpl))),
-        variables = listOf(VariableDefinition("subscriptionId", VariableDirection.INPUT)),
+        variables = listOf(
+            VariableDefinition("subscriptionId", VariableDirection.INPUT),
+            VariableDefinition("subscriptionId", VariableDirection.OUTPUT),
+        ),
         previousElements = listOf("SubProcess_Confirmation"),
         followingElements = listOf("EndEvent_RegistrationCompleted"),
     ),

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -82,7 +82,10 @@ class Camunda7ModelExtractorTest {
                     FlowNodeDefinition("Activity_SendWelcomeMail", BpmnElementType.SERVICE_TASK,
                         displayName = "Send Welcome-Mail",
                         properties = FlowNodeProperties.ServiceTask(c7ServiceTaskById["Activity_SendWelcomeMail"]!!),
-                        variables = listOf(VariableDefinition("subscriptionId", VariableDirection.INPUT, "\${subscriptionId}")),
+                        variables = listOf(
+                            VariableDefinition("subscriptionId", VariableDirection.INPUT, "\${subscriptionId}"),
+                            VariableDefinition("subscriptionId", VariableDirection.OUTPUT, "\${subscriptionId}"),
+                        ),
                         previousElements = listOf("SubProcess_Confirmation"),
                         followingElements = listOf("EndEvent_RegistrationCompleted"),
                         engineSpecificProperties = mapOf(ASYNC_BEFORE_KEY to true, ASYNC_AFTER_KEY to true, EXCLUSIVE_KEY to false)),

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -82,7 +82,10 @@ class OperatonModelExtractorTest {
                     FlowNodeDefinition("Activity_SendWelcomeMail", BpmnElementType.SERVICE_TASK,
                         displayName = "Send Welcome-Mail",
                         properties = FlowNodeProperties.ServiceTask(opServiceTaskById["Activity_SendWelcomeMail"]!!),
-                        variables = listOf(VariableDefinition("subscriptionId", VariableDirection.INPUT, "\${subscriptionId}")),
+                        variables = listOf(
+                            VariableDefinition("subscriptionId", VariableDirection.INPUT, "\${subscriptionId}"),
+                            VariableDefinition("subscriptionId", VariableDirection.OUTPUT, "\${subscriptionId}"),
+                        ),
                         previousElements = listOf("SubProcess_Confirmation"),
                         followingElements = listOf("EndEvent_RegistrationCompleted"),
                         engineSpecificProperties = mapOf(ASYNC_BEFORE_KEY to true, ASYNC_AFTER_KEY to true, EXCLUSIVE_KEY to false)),

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -78,7 +78,10 @@ class ZeebeModelExtractorTest {
                     FlowNodeDefinition("Activity_SendWelcomeMail", BpmnElementType.SERVICE_TASK,
                         displayName = "Send Welcome-Mail",
                         properties = FlowNodeProperties.ServiceTask(zeebeServiceTasks[1]),
-                        variables = listOf(VariableDefinition("subscriptionId", VariableDirection.INPUT, "=subscriptionId")),
+                        variables = listOf(
+                            VariableDefinition("subscriptionId", VariableDirection.INPUT, "=subscriptionId"),
+                            VariableDefinition("subscriptionId", VariableDirection.OUTPUT, "=subscriptionId"),
+                        ),
                         previousElements = listOf("SubProcess_Confirmation"),
                         followingElements = listOf("EndEvent_RegistrationCompleted")),
                     FlowNodeDefinition("CompensationEndEvent_RegistrationAborted", BpmnElementType.END_EVENT,

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
@@ -118,7 +118,7 @@ public final class NewsletterSubscriptionProcessApi {
     }
 
     public static final class ActivitySendWelcomeMail {
-      public static final VariableName.Input SUBSCRIPTION_ID = new VariableName.Input("subscriptionId");
+      public static final VariableName.InOut SUBSCRIPTION_ID = new VariableName.InOut("subscriptionId");
     }
 
     public static final class CallActivityAbortRegistration {

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
@@ -133,7 +133,7 @@ object NewsletterSubscriptionProcessApi {
     }
 
     object ActivitySendWelcomeMail {
-      val SUBSCRIPTION_ID: VariableName.Input = VariableName.Input("subscriptionId")
+      val SUBSCRIPTION_ID: VariableName.InOut = VariableName.InOut("subscriptionId")
     }
 
     object CallActivityAbortRegistration {

--- a/shared/bpmn/c7-subscribe-newsletter.bpmn
+++ b/shared/bpmn/c7-subscribe-newsletter.bpmn
@@ -77,6 +77,7 @@
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="subscriptionId">${subscriptionId}</camunda:inputParameter>
+          <camunda:outputParameter name="subscriptionId">${subscriptionId}</camunda:outputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_09cuvzp</bpmn:incoming>

--- a/shared/bpmn/c8-subscribe-newsletter.bpmn
+++ b/shared/bpmn/c8-subscribe-newsletter.bpmn
@@ -18,6 +18,7 @@
         <zeebe:taskDefinition type="newsletter.sendWelcomeMail" />
         <zeebe:ioMapping>
           <zeebe:input source="=subscriptionId" target="subscriptionId" />
+          <zeebe:output source="=subscriptionId" target="subscriptionId" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_09cuvzp</bpmn:incoming>

--- a/shared/bpmn/operaton-subscribe-newsletter.bpmn
+++ b/shared/bpmn/operaton-subscribe-newsletter.bpmn
@@ -81,6 +81,7 @@
       <bpmn:extensionElements>
         <operaton:inputOutput>
           <operaton:inputParameter name="subscriptionId">${subscriptionId}</operaton:inputParameter>
+          <operaton:outputParameter name="subscriptionId">${subscriptionId}</operaton:outputParameter>
         </operaton:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_09cuvzp</bpmn:incoming>


### PR DESCRIPTION
## Summary

- Adds `subscriptionId` as both `<input>` and `<output>` on `Activity_SendWelcomeMail` in all three sample BPMN files (Zeebe, Camunda 7, Operaton)
- Updates all three extractor tests to assert both INPUT and OUTPUT directions for that variable
- Updates builder golden files (Kotlin + Java) to reflect `VariableName.InOut` instead of `VariableName.Input`

## Why

Demonstrates end-to-end that a task declaring the same variable name in both directions produces a valid, compilable `VariableName.InOut` field rather than duplicate entries — exercising the existing `VariableNameSubtype.chooseFor()` logic that was previously untested in the golden-file comparison.