### PR TITLE
feat(core)!: surface call-activity input/output variable mappings in the generated API

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilder.kt
@@ -13,11 +13,14 @@ import io.miragon.bpmn.domain.GeneratedApiFile
 import io.miragon.bpmn.domain.MergedBpmnModel
 import io.miragon.bpmn.domain.MergedBpmnModel.VariantData
 import io.miragon.bpmn.domain.shared.ApiObjectType
+import io.miragon.bpmn.domain.shared.CallActivityDefinition
+import io.miragon.bpmn.domain.shared.CallActivityMapping
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition
 import io.miragon.bpmn.domain.shared.SequenceFlowDefinition
 import io.miragon.bpmn.domain.shared.VariableDefinition
 import io.miragon.bpmn.domain.shared.VariableMapping
 import io.miragon.bpmn.domain.utils.StringUtils.toCamelCase
+import io.miragon.bpmn.domain.utils.StringUtils.toUpperSnakeCase
 import javax.lang.model.element.Modifier.FINAL
 import javax.lang.model.element.Modifier.PUBLIC
 import javax.lang.model.element.Modifier.STATIC
@@ -255,12 +258,55 @@ class JavaProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<Ty
         override fun shouldWrite(modelApi: BpmnModelApi) = modelApi.model.callActivities.isNotEmpty()
 
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
-            val processIdClass = ClassName.get(RUNTIME_PACKAGE, "ProcessId")
             val callActivitiesBuilder = TypeSpec.classBuilder("CallActivities").addModifiers(PUBLIC, STATIC, FINAL)
-            modelApi.model.callActivities.forEach { callActivity ->
-                callActivitiesBuilder.addField(createTypedAttribute(callActivity, processIdClass))
-            }
+                .addJavadoc(
+                    "Call activities grouped by element. Each nested class exposes the called {@code PROCESS_ID} plus " +
+                        "the variable mappings passed into ({@code Inputs}) and returned from ({@code Outputs}) the called process.\n"
+                )
+            modelApi.model.callActivities
+                .sortedBy { it.getRawName() }
+                .forEach { callActivity -> callActivitiesBuilder.addType(buildCallActivityClass(callActivity)) }
             builder.addType(callActivitiesBuilder.build())
+        }
+
+        private fun buildCallActivityClass(callActivity: CallActivityDefinition): TypeSpec {
+            val processIdClass = ClassName.get(RUNTIME_PACKAGE, "ProcessId")
+            val classBuilder = TypeSpec.classBuilder(callActivity.getRawName().toCamelCase()).addModifiers(PUBLIC, STATIC, FINAL)
+            classBuilder.addField(
+                FieldSpec.builder(processIdClass, "PROCESS_ID").addModifiers(PUBLIC, STATIC, FINAL)
+                    .initializer("new \$T(\$S)", processIdClass, callActivity.getValue())
+                    .build()
+            )
+            buildMappingsClass("Inputs", callActivity.inputMappings)?.let { classBuilder.addType(it) }
+            buildMappingsClass("Outputs", callActivity.outputMappings)?.let { classBuilder.addType(it) }
+            return classBuilder.build()
+        }
+
+        private fun buildMappingsClass(className: String, mappings: List<CallActivityMapping>): TypeSpec? {
+            val withTarget = mappings
+                .filter { !it.target.isNullOrBlank() }
+                .sortedBy { it.target!!.toUpperSnakeCase() }
+            if (withTarget.isEmpty()) return null
+            val mappingClass = ClassName.get(RUNTIME_PACKAGE, "InputOutputMapping")
+            val mappingsBuilder = TypeSpec.classBuilder(className).addModifiers(PUBLIC, STATIC, FINAL)
+            withTarget.forEach { mapping -> mappingsBuilder.addField(buildMappingField(mapping, mappingClass)) }
+            return mappingsBuilder.build()
+        }
+
+        private fun buildMappingField(mapping: CallActivityMapping, mappingClass: ClassName): FieldSpec {
+            val target = mapping.target!!
+            val sourceBlock = if (mapping.source != null) CodeBlock.of("\$S", mapping.source) else CodeBlock.of("null")
+            val sourceExpressionBlock = if (mapping.sourceExpression != null) CodeBlock.of("\$S", mapping.sourceExpression) else CodeBlock.of("null")
+            val initializer = CodeBlock.builder()
+                .add("new \$T(\$S, ", mappingClass, target)
+                .add(sourceBlock)
+                .add(", ")
+                .add(sourceExpressionBlock)
+                .add(")")
+                .build()
+            return FieldSpec.builder(mappingClass, target.toUpperSnakeCase()).addModifiers(PUBLIC, STATIC, FINAL)
+                .initializer(initializer)
+                .build()
         }
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
@@ -15,11 +15,14 @@ import io.miragon.bpmn.domain.GeneratedApiFile
 import io.miragon.bpmn.domain.MergedBpmnModel
 import io.miragon.bpmn.domain.MergedBpmnModel.VariantData
 import io.miragon.bpmn.domain.shared.ApiObjectType
+import io.miragon.bpmn.domain.shared.CallActivityDefinition
+import io.miragon.bpmn.domain.shared.CallActivityMapping
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition
 import io.miragon.bpmn.domain.shared.SequenceFlowDefinition
 import io.miragon.bpmn.domain.shared.VariableDefinition
 import io.miragon.bpmn.domain.shared.VariableMapping
 import io.miragon.bpmn.domain.utils.StringUtils.toCamelCase
+import io.miragon.bpmn.domain.utils.StringUtils.toUpperSnakeCase
 
 /**
  * Generates the type-safe API contract for a single BPMN process as a Kotlin object file.
@@ -248,12 +251,49 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
         override fun shouldWrite(modelApi: BpmnModelApi) = modelApi.model.callActivities.isNotEmpty()
 
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
-            val processIdClass = ClassName(RUNTIME_PACKAGE, "ProcessId")
             val callActivitiesBuilder = TypeSpec.objectBuilder("CallActivities")
-            modelApi.model.callActivities.forEach { callActivity ->
-                callActivitiesBuilder.addProperty(createTypedAttribute(callActivity, processIdClass))
-            }
+                .addKdoc(
+                    "Call activities grouped by element. Each nested object exposes the called `PROCESS_ID` plus " +
+                        "the variable mappings passed into (`Inputs`) and returned from (`Outputs`) the called process.\n"
+                )
+            modelApi.model.callActivities
+                .sortedBy { it.getRawName() }
+                .forEach { callActivity -> callActivitiesBuilder.addType(buildCallActivityObject(callActivity)) }
             builder.addType(callActivitiesBuilder.build())
+        }
+
+        private fun buildCallActivityObject(callActivity: CallActivityDefinition): TypeSpec {
+            val processIdClass = ClassName(RUNTIME_PACKAGE, "ProcessId")
+            val objectBuilder = TypeSpec.objectBuilder(callActivity.getRawName().toCamelCase())
+            objectBuilder.addProperty(
+                PropertySpec.builder("PROCESS_ID", processIdClass)
+                    .initializer("%T(%L)", processIdClass, stringLiteral(callActivity.getValue()))
+                    .build()
+            )
+            buildMappingsObject("Inputs", callActivity.inputMappings)?.let { objectBuilder.addType(it) }
+            buildMappingsObject("Outputs", callActivity.outputMappings)?.let { objectBuilder.addType(it) }
+            return objectBuilder.build()
+        }
+
+        private fun buildMappingsObject(objectName: String, mappings: List<CallActivityMapping>): TypeSpec? {
+            val withTarget = mappings
+                .filter { !it.target.isNullOrBlank() }
+                .sortedBy { it.target!!.toUpperSnakeCase() }
+            if (withTarget.isEmpty()) return null
+            val mappingClass = ClassName(RUNTIME_PACKAGE, "InputOutputMapping")
+            val mappingsBuilder = TypeSpec.objectBuilder(objectName)
+            withTarget.forEach { mapping -> mappingsBuilder.addProperty(buildMappingProperty(mapping, mappingClass)) }
+            return mappingsBuilder.build()
+        }
+
+        private fun buildMappingProperty(mapping: CallActivityMapping, mappingClass: ClassName): PropertySpec {
+            val target = mapping.target!!
+            val args = CodeBlock.builder().add("target = %L", stringLiteral(target))
+            if (mapping.source != null) args.add(", source = %L", stringLiteral(mapping.source))
+            if (mapping.sourceExpression != null) args.add(", sourceExpression = %L", stringLiteral(mapping.sourceExpression))
+            return PropertySpec.builder(target.toUpperSnakeCase(), mappingClass)
+                .initializer("%T(%L)", mappingClass, args.build())
+                .build()
         }
     }
 

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/codegen/builder/NewsletterFlowNodes.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/codegen/builder/NewsletterFlowNodes.kt
@@ -2,6 +2,7 @@ package io.miragon.bpmn.adapter.outbound.codegen.builder
 
 import io.miragon.bpmn.domain.shared.BpmnElementType
 import io.miragon.bpmn.domain.shared.CallActivityDefinition
+import io.miragon.bpmn.domain.shared.CallActivityMapping
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition
 import io.miragon.bpmn.domain.shared.FlowNodeProperties
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition
@@ -19,7 +20,17 @@ internal fun buildSubscribeNewsletterFlowNodes(
     FlowNodeDefinition(
         id = "CallActivity_AbortRegistration",
         elementType = BpmnElementType.CALL_ACTIVITY,
-        properties = FlowNodeProperties.CallActivity(CallActivityDefinition("CallActivity_AbortRegistration", "abort-registration")),
+        properties = FlowNodeProperties.CallActivity(
+            CallActivityDefinition(
+                id = "CallActivity_AbortRegistration",
+                calledElement = "abort-registration",
+                mappings = listOf(
+                    CallActivityMapping(direction = VariableDirection.INPUT, source = "subscriptionId", target = "childSubscriptionId"),
+                    CallActivityMapping(direction = VariableDirection.INPUT, sourceExpression = "\${reasonCode}", target = "childReasonCode"),
+                    CallActivityMapping(direction = VariableDirection.OUTPUT, source = "childAbortResult", target = "abortResult"),
+                ),
+            ),
+        ),
         variables = listOf(VariableDefinition("subscriptionId", VariableDirection.INPUT)),
         previousElements = listOf("Timer_After3Days"),
         followingElements = listOf("CompensationEndEvent_RegistrationAborted"),

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
@@ -7,6 +7,7 @@ import io.miragon.bpmn.runtime.BpmnFlow;
 import io.miragon.bpmn.runtime.BpmnRelations;
 import io.miragon.bpmn.runtime.BpmnTimer;
 import io.miragon.bpmn.runtime.ElementId;
+import io.miragon.bpmn.runtime.InputOutputMapping;
 import io.miragon.bpmn.runtime.MessageName;
 import io.miragon.bpmn.runtime.ProcessId;
 import io.miragon.bpmn.runtime.SignalName;
@@ -60,8 +61,23 @@ public final class NewsletterSubscriptionProcessApi {
     public static final ElementId TIMER_EVERY_DAY = new ElementId("Timer_EveryDay");
   }
 
+  /**
+   * Call activities grouped by element. Each nested class exposes the called {@code PROCESS_ID} plus the variable mappings passed into ({@code Inputs}) and returned from ({@code Outputs}) the called process.
+   */
   public static final class CallActivities {
-    public static final ProcessId CALL_ACTIVITY_ABORT_REGISTRATION = new ProcessId("abort-registration");
+    public static final class CallActivityAbortRegistration {
+      public static final ProcessId PROCESS_ID = new ProcessId("abort-registration");
+
+      public static final class Inputs {
+        public static final InputOutputMapping CHILD_REASON_CODE = new InputOutputMapping("childReasonCode", null, "${reasonCode}");
+
+        public static final InputOutputMapping CHILD_SUBSCRIPTION_ID = new InputOutputMapping("childSubscriptionId", "subscriptionId", null);
+      }
+
+      public static final class Outputs {
+        public static final InputOutputMapping ABORT_RESULT = new InputOutputMapping("abortResult", "childAbortResult", null);
+      }
+    }
   }
 
   /**

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
@@ -9,6 +9,7 @@ import io.miragon.bpmn.runtime.BpmnFlow
 import io.miragon.bpmn.runtime.BpmnRelations
 import io.miragon.bpmn.runtime.BpmnTimer
 import io.miragon.bpmn.runtime.ElementId
+import io.miragon.bpmn.runtime.InputOutputMapping
 import io.miragon.bpmn.runtime.MessageName
 import io.miragon.bpmn.runtime.ProcessId
 import io.miragon.bpmn.runtime.SignalName
@@ -72,8 +73,26 @@ object NewsletterSubscriptionProcessApi {
     val TIMER_EVERY_DAY: ElementId = ElementId("Timer_EveryDay")
   }
 
+  /**
+   * Call activities grouped by element. Each nested object exposes the called `PROCESS_ID` plus the variable mappings passed into (`Inputs`) and returned from (`Outputs`) the called process.
+   */
   object CallActivities {
-    val CALL_ACTIVITY_ABORT_REGISTRATION: ProcessId = ProcessId("abort-registration")
+    object CallActivityAbortRegistration {
+      val PROCESS_ID: ProcessId = ProcessId("abort-registration")
+
+      object Inputs {
+        val CHILD_REASON_CODE: InputOutputMapping =
+            InputOutputMapping(target = "childReasonCode", sourceExpression = $$"""${reasonCode}""")
+
+        val CHILD_SUBSCRIPTION_ID: InputOutputMapping =
+            InputOutputMapping(target = "childSubscriptionId", source = "subscriptionId")
+      }
+
+      object Outputs {
+        val ABORT_RESULT: InputOutputMapping =
+            InputOutputMapping(target = "abortResult", source = "childAbortResult")
+      }
+    }
   }
 
   /**

--- a/bpmn-to-code-runtime/src/main/kotlin/io/miragon/bpmn/runtime/InputOutputMapping.kt
+++ b/bpmn-to-code-runtime/src/main/kotlin/io/miragon/bpmn/runtime/InputOutputMapping.kt
@@ -1,0 +1,21 @@
+package io.miragon.bpmn.runtime
+
+/**
+ * A variable mapping between two scopes — e.g. the parent process and the called child process of a
+ * call activity.
+ *
+ * [target] is the destination variable name (the name the variable gets in the receiving scope) and
+ * is always present. The origin is either a plain [source] variable or a [sourceExpression]; which one
+ * is populated depends on the engine:
+ * - Camunda 7 / Operaton set [source] (plain variable) or [sourceExpression] (a `${...}` expression).
+ * - Zeebe sets [source] to a FEEL expression (e.g. `=orderId`) and always leaves [sourceExpression] null.
+ *
+ * `toString()` returns [target], so `.target` is optional in string contexts.
+ */
+data class InputOutputMapping(
+    val target: String,
+    val source: String? = null,
+    val sourceExpression: String? = null,
+) {
+    override fun toString(): String = target
+}

--- a/bpmn-to-code-runtime/src/test/kotlin/io/miragon/bpmn/runtime/RuntimeTypesTest.kt
+++ b/bpmn-to-code-runtime/src/test/kotlin/io/miragon/bpmn/runtime/RuntimeTypesTest.kt
@@ -79,4 +79,25 @@ class RuntimeTypesTest {
         assertThat(BpmnError("NotFound", "E_404").code).isEqualTo("E_404")
         assertThat(BpmnEscalation("OutOfHours", "E_HRS").name).isEqualTo("OutOfHours")
     }
+
+    @Test
+    fun `InputOutputMapping keeps target plus source or sourceExpression`() {
+        val plain = InputOutputMapping(target = "childSubscriptionId", source = "subscriptionId")
+        val expression = InputOutputMapping(target = "childReasonCode", sourceExpression = "\${reasonCode}")
+
+        assertThat(plain.target).isEqualTo("childSubscriptionId")
+        assertThat(plain.source).isEqualTo("subscriptionId")
+        assertThat(plain.sourceExpression).isNull()
+
+        assertThat(expression.sourceExpression).isEqualTo("\${reasonCode}")
+        assertThat(expression.source).isNull()
+    }
+
+    @Test
+    fun `InputOutputMapping defaults source and sourceExpression to null and exposes target via toString`() {
+        val mapping = InputOutputMapping(target = "abortResult")
+        assertThat(mapping.source).isNull()
+        assertThat(mapping.sourceExpression).isNull()
+        assertThat(mapping.toString()).isEqualTo("abortResult")
+    }
 }

--- a/docs/guide/generated-api.md
+++ b/docs/guide/generated-api.md
@@ -11,7 +11,7 @@ The generated Process API is an `object` (Kotlin) or `class` (Java) with nested 
 | `PROCESS_ID` | The process identifier from the BPMN model |
 | `PROCESS_ENGINE` | The engine the API was generated for, as a typed `BpmnEngine` enum (`ZEEBE`, `CAMUNDA_7`, `OPERATON`) |
 | `Elements` | All flow node IDs (tasks, events, gateways, subprocesses) |
-| `CallActivities` | Called process IDs for call activity elements |
+| `CallActivities` | Per call activity: the called `PROCESS_ID` plus `Inputs` / `Outputs` variable mappings (`InputOutputMapping`) |
 | `Messages` | Message names from message events and receive tasks |
 | `ServiceTasks` | Worker types / topics / delegate expressions from service tasks |
 | `Timers` | Timer configurations with type and value (`BpmnTimer`) |
@@ -41,6 +41,8 @@ import io.miragon.bpmn.runtime.BpmnError
 import io.miragon.bpmn.runtime.BpmnFlow
 import io.miragon.bpmn.runtime.BpmnRelations
 import io.miragon.bpmn.runtime.BpmnTimer
+import io.miragon.bpmn.runtime.InputOutputMapping
+import io.miragon.bpmn.runtime.ProcessId
 import io.miragon.bpmn.runtime.VariableName
 
 object NewsletterSubscriptionProcessApi {
@@ -61,7 +63,17 @@ object NewsletterSubscriptionProcessApi {
   }
 
   object CallActivities {
-    const val CALL_ACTIVITY_ABORT_REGISTRATION: String = "abort-registration"
+    object CallActivityAbortRegistration {
+      val PROCESS_ID: ProcessId = ProcessId("abort-registration")
+
+      object Inputs {
+        val CHILD_SUBSCRIPTION_ID: InputOutputMapping = InputOutputMapping(target = "childSubscriptionId", source = "subscriptionId")
+      }
+
+      object Outputs {
+        val ABORT_RESULT: InputOutputMapping = InputOutputMapping(target = "abortResult", source = "childAbortResult")
+      }
+    }
   }
 
   object Messages {
@@ -210,6 +222,46 @@ object Variables {
 ```
 
 A sub-object is only emitted when it contains at least one variable — one-sided splits (`Inputs` only or `Outputs` only) are legal. An element without any directional variables is omitted from `Variables` entirely.
+
+## Call-Activity Variable Mappings
+
+Call activities map variables between the parent process and the called child process. Unlike the plain `Variables` section — which only carries the parent-scope variable name — `CallActivities` exposes the **full mapping**: the `target` (the name the variable gets in the receiving scope) together with its `source` / `sourceExpression` (the origin). Each call activity becomes a nested object holding the called `PROCESS_ID` plus `Inputs` (variables passed **into** the child) and `Outputs` (variables returned **to** the parent):
+
+```kotlin
+object CallActivities {
+    object CallActivityAbortRegistration {
+        val PROCESS_ID: ProcessId = ProcessId("abort-registration")
+
+        object Inputs {
+            val CHILD_SUBSCRIPTION_ID: InputOutputMapping = InputOutputMapping(target = "childSubscriptionId", source = "subscriptionId")
+            val CHILD_REASON_CODE: InputOutputMapping = InputOutputMapping(target = "childReasonCode", sourceExpression = "\${reasonCode}")
+        }
+
+        object Outputs {
+            val ABORT_RESULT: InputOutputMapping = InputOutputMapping(target = "abortResult", source = "childAbortResult")
+        }
+    }
+}
+```
+
+Each mapping is an `InputOutputMapping`; constant names are derived from the `target`. `Inputs` / `Outputs` are only emitted when non-empty.
+
+```kotlin
+data class InputOutputMapping(
+    val target: String,            // destination variable name (always present)
+    val source: String? = null,    // origin variable (plain name, or a FEEL expression on Zeebe)
+    val sourceExpression: String? = null, // origin expression — Camunda 7 / Operaton only
+)
+```
+
+::: tip Engine differences
+The `target` is populated the same way for every engine. The origin differs:
+
+- **Camunda 7 / Operaton** (`camunda:in` / `camunda:out`): `source` holds a plain variable name, `sourceExpression` a `${...}` expression.
+- **Zeebe** (`zeebe:input` / `zeebe:output`): `source` holds a FEEL expression (e.g. `=orderId`) and `sourceExpression` is always `null`.
+
+The "pass all variables" mode (`variables="all"` / `propagateAll{Parent,Child}Variables`) is not surfaced as constants.
+:::
 
 ## Variable Extraction
 

--- a/docs/validate/testing.md
+++ b/docs/validate/testing.md
@@ -248,6 +248,10 @@ For a rule that should behave the same across engines, test `!= true` to mean "d
 variables" (this treats Camunda's "not declared" and Zeebe's explicit `false` alike).
 :::
 
+::: tip Also available in the generated API
+The same mappings are surfaced in the [generated Process API](/guide/generated-api#call-activity-variable-mappings) under `CallActivities.<CallActivity>.Inputs` / `.Outputs` as `InputOutputMapping` constants, so production code can reference them type-safely too — not just validation rules.
+:::
+
 ::: tip ValidationContext
 `context.model` gives you the full `BpmnModel` — flow nodes, service tasks, call activities, messages, signals, errors, timers, and variables. `context.engine` tells you which engine was selected, so you can write engine-specific rules.
 :::


### PR DESCRIPTION
## What
The generated `CallActivities` object now exposes each call activity's input/output variable mappings as type-safe constants: one nested object per call activity with `PROCESS_ID` plus `Inputs` / `Outputs`, where each mapping is an `InputOutputMapping` (`target` + `source` / `sourceExpression`). Works for Kotlin and Java output.

Engine-aware (no engine branching in codegen): Camunda 7 / Operaton populate `source` / `sourceExpression`, Zeebe a FEEL `source`.

## Why
Previously only the called process id was surfaced. The parent↔child variable mappings — especially the child-scope `target` — were extracted into the domain model but never rendered, so users couldn't reference or test which variables a call activity passes into/returns from the called process. See #19.

## ⚠️ Breaking change
`CallActivities.CALL_ACTIVITY_X: ProcessId` → `CallActivities.CallActivityX.PROCESS_ID`. The new `InputOutputMapping` runtime type is additive.

## Notes
- The runtime type name (`InputOutputMapping`) and the mapping data model are still open for discussion — see the design notes on #19.
- `propagateAll*` is intentionally not surfaced as constants (see #19 discussion).

Closes #19
