### PR TITLE
feat(core): expose element type in generated BpmnRelations

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilder.kt
@@ -7,6 +7,7 @@ import com.palantir.javapoet.JavaFile
 import com.palantir.javapoet.TypeSpec
 import io.miragon.bpmn.adapter.outbound.codegen.CodeGenerationAdapter
 import io.miragon.bpmn.adapter.outbound.codegen.writer.ObjectWriter
+import io.miragon.bpmn.adapter.outbound.shared.ElementTypeName
 import io.miragon.bpmn.domain.BpmnModel
 import io.miragon.bpmn.domain.BpmnModelApi
 import io.miragon.bpmn.domain.GeneratedApiFile
@@ -204,7 +205,7 @@ class JavaProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<Ty
         val bpmnRelationsClass = ClassName.get(RUNTIME_PACKAGE, "BpmnRelations")
         val relationsBuilder = TypeSpec.classBuilder("Relations").addModifiers(PUBLIC, STATIC, FINAL)
             .addJavadoc(
-                "Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).\n" +
+                "Per-element graph metadata (elementType / previousElements / followingElements / parentId / boundary attachments).\n" +
                     "Intended for tooling and tests, not worker runtime code.\n"
             )
         flowNodes
@@ -235,6 +236,8 @@ class JavaProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<Ty
             .add(attachedToRefBlock)
             .add(", ")
             .add(javaListLiteral(node.attachedElements))
+            .add(", ")
+            .add("\$S", ElementTypeName.of(node.nodeType))
             .add(")")
             .build()
     }

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
@@ -9,6 +9,7 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import io.miragon.bpmn.adapter.outbound.codegen.CodeGenerationAdapter
 import io.miragon.bpmn.adapter.outbound.codegen.writer.ObjectWriter
+import io.miragon.bpmn.adapter.outbound.shared.ElementTypeName
 import io.miragon.bpmn.domain.BpmnModel
 import io.miragon.bpmn.domain.BpmnModelApi
 import io.miragon.bpmn.domain.GeneratedApiFile
@@ -209,7 +210,7 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
         val bpmnRelationsClass = ClassName(RUNTIME_PACKAGE, "BpmnRelations")
         val relationsBuilder = TypeSpec.objectBuilder("Relations")
             .addKdoc(
-                "Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).\n" +
+                "Per-element graph metadata (elementType / previousElements / followingElements / parentId / boundary attachments).\n" +
                     "Intended for tooling and tests, not worker runtime code."
             )
         flowNodes
@@ -232,6 +233,7 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
             add("parentId = %L,\n", nullableStringLiteral(node.parentId))
             add("attachedToRef = %L,\n", nullableStringLiteral(node.attachedToRef))
             add("attachedElements = %L,\n", listLiteral(node.attachedElements))
+            add("elementType = %S,\n", ElementTypeName.of(node.nodeType))
             unindent()
             add(")")
         }.build()

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/json/BpmnJsonMapper.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/json/BpmnJsonMapper.kt
@@ -10,6 +10,7 @@ import io.miragon.bpmn.adapter.outbound.json.model.MessageJson
 import io.miragon.bpmn.adapter.outbound.json.model.SequenceFlowJson
 import io.miragon.bpmn.adapter.outbound.json.model.SignalJson
 import io.miragon.bpmn.adapter.outbound.json.model.VariantJson
+import io.miragon.bpmn.adapter.outbound.shared.ElementTypeName
 import io.miragon.bpmn.domain.BpmnModel
 import io.miragon.bpmn.domain.MergedBpmnModel
 import io.miragon.bpmn.domain.ProcessModel

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/shared/ElementTypeName.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/shared/ElementTypeName.kt
@@ -1,4 +1,4 @@
-package io.miragon.bpmn.adapter.outbound.json
+package io.miragon.bpmn.adapter.outbound.shared
 
 import io.miragon.bpmn.domain.shared.BpmnNodeType
 import io.miragon.bpmn.domain.shared.EventDefinitionType
@@ -7,10 +7,10 @@ import io.miragon.bpmn.domain.shared.SubProcessKind
 import io.miragon.bpmn.domain.shared.TaskKind
 
 /**
- * Renders the two-axis [BpmnNodeType] domain model into the flat `elementType` string used by the
- * generated JSON.
+ * Renders the two-axis [BpmnNodeType] domain model into the flat `elementType` string shared by the
+ * outbound representations — the generated JSON export and the generated Process API.
  *
- * This is the single boundary between the internal node-type model and the JSON output vocabulary.
+ * This is the single boundary between the internal node-type model and that output vocabulary.
  * Tasks, gateways and activities map to their flat name; event nodes surface their concrete
  * [definitionType][BpmnNodeType.Event.definitionType] as a prefix on the shape
  * (e.g. `ERROR_BOUNDARY_EVENT`), so consumers can tell a timer from an error without cross-referencing.

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/codegen/builder/NewsletterFlowNodes.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/codegen/builder/NewsletterFlowNodes.kt
@@ -3,6 +3,7 @@ package io.miragon.bpmn.adapter.outbound.codegen.builder
 import io.miragon.bpmn.domain.shared.SubProcessKind
 import io.miragon.bpmn.domain.shared.BpmnNodeType
 import io.miragon.bpmn.domain.shared.EventShape
+import io.miragon.bpmn.domain.shared.EventDefinitionType
 import io.miragon.bpmn.domain.shared.TaskKind
 import io.miragon.bpmn.domain.shared.CallActivityDefinition
 import io.miragon.bpmn.domain.shared.CallActivityMapping
@@ -69,12 +70,12 @@ internal fun buildSubscribeNewsletterFlowNodes(
     ),
     FlowNodeDefinition(
         id = "CompensationEndEvent_RegistrationAborted",
-        nodeType = BpmnNodeType.Event(EventShape.END_EVENT),
+        nodeType = BpmnNodeType.Event(EventShape.END_EVENT, EventDefinitionType.COMPENSATION),
         previousElements = listOf("CallActivity_AbortRegistration"),
     ),
     FlowNodeDefinition(
         id = "CompensationEvent_OnSubscriptionCounter",
-        nodeType = BpmnNodeType.Event(EventShape.BOUNDARY_EVENT),
+        nodeType = BpmnNodeType.Event(EventShape.BOUNDARY_EVENT, EventDefinitionType.COMPENSATION),
         attachedToRef = "serviceTask_incrementSubscriptionCounter",
     ),
     FlowNodeDefinition(
@@ -90,7 +91,7 @@ internal fun buildSubscribeNewsletterFlowNodes(
     ),
     FlowNodeDefinition(
         id = "EndEvent_RegistrationNotPossible",
-        nodeType = BpmnNodeType.Event(EventShape.END_EVENT),
+        nodeType = BpmnNodeType.Event(EventShape.END_EVENT, EventDefinitionType.SIGNAL),
         previousElements = listOf("ErrorEvent_InvalidMail"),
     ),
     FlowNodeDefinition(
@@ -101,7 +102,7 @@ internal fun buildSubscribeNewsletterFlowNodes(
     ),
     FlowNodeDefinition(
         id = "ErrorEvent_InvalidMail",
-        nodeType = BpmnNodeType.Event(EventShape.BOUNDARY_EVENT),
+        nodeType = BpmnNodeType.Event(EventShape.BOUNDARY_EVENT, EventDefinitionType.ERROR),
         attachedToRef = "SubProcess_Confirmation",
         followingElements = listOf("EndEvent_RegistrationNotPossible"),
     ),
@@ -122,7 +123,7 @@ internal fun buildSubscribeNewsletterFlowNodes(
     ),
     FlowNodeDefinition(
         id = "StartEvent_SubmitRegistrationForm",
-        nodeType = BpmnNodeType.Event(EventShape.START_EVENT),
+        nodeType = BpmnNodeType.Event(EventShape.START_EVENT, EventDefinitionType.MESSAGE),
         variables = listOf(VariableDefinition("subscriptionId", VariableDirection.OUTPUT)),
         followingElements = listOf("serviceTask_incrementSubscriptionCounter"),
     ),
@@ -135,14 +136,14 @@ internal fun buildSubscribeNewsletterFlowNodes(
     ),
     FlowNodeDefinition(
         id = "Timer_After3Days",
-        nodeType = BpmnNodeType.Event(EventShape.BOUNDARY_EVENT),
+        nodeType = BpmnNodeType.Event(EventShape.BOUNDARY_EVENT, EventDefinitionType.TIMER),
         properties = FlowNodeProperties.Timer(TimerDefinition("Timer_After3Days", "Duration", "\${testVariable}")),
         attachedToRef = "SubProcess_Confirmation",
         followingElements = listOf("CallActivity_AbortRegistration"),
     ),
     FlowNodeDefinition(
         id = "Timer_EveryDay",
-        nodeType = BpmnNodeType.Event(EventShape.BOUNDARY_EVENT),
+        nodeType = BpmnNodeType.Event(EventShape.BOUNDARY_EVENT, EventDefinitionType.TIMER),
         properties = FlowNodeProperties.Timer(TimerDefinition("Timer_EveryDay", "Duration", "PT1M")),
         attachedToRef = "Activity_ConfirmRegistration",
         parentId = "SubProcess_Confirmation",

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/shared/ElementTypeNameTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/shared/ElementTypeNameTest.kt
@@ -1,4 +1,4 @@
-package io.miragon.bpmn.adapter.outbound.json
+package io.miragon.bpmn.adapter.outbound.shared
 
 import io.miragon.bpmn.domain.shared.BpmnNodeType
 import io.miragon.bpmn.domain.shared.EventShape

--- a/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiJava.txt
@@ -145,45 +145,45 @@ public final class SendNewsletterProcessApi {
       }
 
       /**
-       * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).
+       * Per-element graph metadata (elementType / previousElements / followingElements / parentId / boundary attachments).
        * Intended for tooling and tests, not worker runtime code.
        */
       public static final class Relations {
-        public static final BpmnRelations END_EVENT_EDITION_SENT = new BpmnRelations(null, List.of("serviceTask_notifyAuthor"), List.of(), null, null, List.of());
+        public static final BpmnRelations END_EVENT_EDITION_SENT = new BpmnRelations(null, List.of("serviceTask_notifyAuthor"), List.of(), null, null, List.of(), "END_EVENT");
 
-        public static final BpmnRelations END_EVENT_ISSUE_RESOLVED = new BpmnRelations(null, List.of("timer_noRejectionForOneDay"), List.of(), "eventSubProcess_errorHandling", null, List.of());
+        public static final BpmnRelations END_EVENT_ISSUE_RESOLVED = new BpmnRelations(null, List.of("timer_noRejectionForOneDay"), List.of(), "eventSubProcess_errorHandling", null, List.of(), "END_EVENT");
 
-        public static final BpmnRelations END_EVENT_NO_SUBSCRIBERS = new BpmnRelations(null, List.of("gateway_hasSubscribers"), List.of(), null, null, List.of());
+        public static final BpmnRelations END_EVENT_NO_SUBSCRIBERS = new BpmnRelations(null, List.of("gateway_hasSubscribers"), List.of(), null, null, List.of(), "END_EVENT");
 
-        public static final BpmnRelations ESCALATION_END_EVENT_NOFITY_SUPPORT = new BpmnRelations(null, List.of("gateway_canSendAgain"), List.of(), "eventSubProcess_errorHandling", null, List.of());
+        public static final BpmnRelations ESCALATION_END_EVENT_NOFITY_SUPPORT = new BpmnRelations(null, List.of("gateway_canSendAgain"), List.of(), "eventSubProcess_errorHandling", null, List.of(), "ESCALATION_END_EVENT");
 
-        public static final BpmnRelations ESCALATION_END_EVENT_NOFITY_SUPPORT_AFTER_REPEATED_ERROR = new BpmnRelations(null, List.of("event_mailRejectedAgain"), List.of(), "eventSubProcess_errorHandling", null, List.of());
+        public static final BpmnRelations ESCALATION_END_EVENT_NOFITY_SUPPORT_AFTER_REPEATED_ERROR = new BpmnRelations(null, List.of("event_mailRejectedAgain"), List.of(), "eventSubProcess_errorHandling", null, List.of(), "END_EVENT");
 
-        public static final BpmnRelations EVENT_GATEWAY_AFTER_SENDING_AGAIN = new BpmnRelations(null, List.of("serviceTask_sendMailAgain"), List.of("timer_noRejectionForOneDay", "event_mailRejectedAgain"), "eventSubProcess_errorHandling", null, List.of());
+        public static final BpmnRelations EVENT_GATEWAY_AFTER_SENDING_AGAIN = new BpmnRelations(null, List.of("serviceTask_sendMailAgain"), List.of("timer_noRejectionForOneDay", "event_mailRejectedAgain"), "eventSubProcess_errorHandling", null, List.of(), "EVENT_BASED_GATEWAY");
 
-        public static final BpmnRelations EVENT_SUB_PROCESS_ERROR_HANDLING = new BpmnRelations(null, List.of(), List.of(), null, null, List.of());
+        public static final BpmnRelations EVENT_SUB_PROCESS_ERROR_HANDLING = new BpmnRelations(null, List.of(), List.of(), null, null, List.of(), "SUB_PROCESS");
 
-        public static final BpmnRelations EVENT_MAIL_REJECTED = new BpmnRelations(null, List.of(), List.of("serviceTask_analyzeError"), "eventSubProcess_errorHandling", null, List.of());
+        public static final BpmnRelations EVENT_MAIL_REJECTED = new BpmnRelations(null, List.of(), List.of("serviceTask_analyzeError"), "eventSubProcess_errorHandling", null, List.of(), "MESSAGE_START_EVENT");
 
-        public static final BpmnRelations EVENT_MAIL_REJECTED_AGAIN = new BpmnRelations(null, List.of("eventGateway_afterSendingAgain"), List.of("escalationEndEvent_nofitySupportAfterRepeatedError"), "eventSubProcess_errorHandling", null, List.of());
+        public static final BpmnRelations EVENT_MAIL_REJECTED_AGAIN = new BpmnRelations(null, List.of("eventGateway_afterSendingAgain"), List.of("escalationEndEvent_nofitySupportAfterRepeatedError"), "eventSubProcess_errorHandling", null, List.of(), "MESSAGE_INTERMEDIATE_CATCH_EVENT");
 
-        public static final BpmnRelations GATEWAY_CAN_SEND_AGAIN = new BpmnRelations(null, List.of("serviceTask_analyzeError"), List.of("serviceTask_sendMailAgain", "escalationEndEvent_nofitySupport"), "eventSubProcess_errorHandling", null, List.of());
+        public static final BpmnRelations GATEWAY_CAN_SEND_AGAIN = new BpmnRelations(null, List.of("serviceTask_analyzeError"), List.of("serviceTask_sendMailAgain", "escalationEndEvent_nofitySupport"), "eventSubProcess_errorHandling", null, List.of(), "EXCLUSIVE_GATEWAY");
 
-        public static final BpmnRelations GATEWAY_HAS_SUBSCRIBERS = new BpmnRelations(null, List.of("serviceTask_loadSubscribers"), List.of("serviceTask_sendToSubscriber", "endEvent_noSubscribers"), null, null, List.of());
+        public static final BpmnRelations GATEWAY_HAS_SUBSCRIBERS = new BpmnRelations(null, List.of("serviceTask_loadSubscribers"), List.of("serviceTask_sendToSubscriber", "endEvent_noSubscribers"), null, null, List.of(), "EXCLUSIVE_GATEWAY");
 
-        public static final BpmnRelations SERVICE_TASK_ANALYZE_ERROR = new BpmnRelations(null, List.of("event_mailRejected"), List.of("gateway_canSendAgain"), "eventSubProcess_errorHandling", null, List.of());
+        public static final BpmnRelations SERVICE_TASK_ANALYZE_ERROR = new BpmnRelations(null, List.of("event_mailRejected"), List.of("gateway_canSendAgain"), "eventSubProcess_errorHandling", null, List.of(), "SERVICE_TASK");
 
-        public static final BpmnRelations SERVICE_TASK_LOAD_SUBSCRIBERS = new BpmnRelations(null, List.of("startEvent_editionCreated"), List.of("gateway_hasSubscribers"), null, null, List.of());
+        public static final BpmnRelations SERVICE_TASK_LOAD_SUBSCRIBERS = new BpmnRelations(null, List.of("startEvent_editionCreated"), List.of("gateway_hasSubscribers"), null, null, List.of(), "SERVICE_TASK");
 
-        public static final BpmnRelations SERVICE_TASK_NOTIFY_AUTHOR = new BpmnRelations(null, List.of("serviceTask_sendToSubscriber"), List.of("endEvent_editionSent"), null, null, List.of());
+        public static final BpmnRelations SERVICE_TASK_NOTIFY_AUTHOR = new BpmnRelations(null, List.of("serviceTask_sendToSubscriber"), List.of("endEvent_editionSent"), null, null, List.of(), "SERVICE_TASK");
 
-        public static final BpmnRelations SERVICE_TASK_SEND_MAIL_AGAIN = new BpmnRelations(null, List.of("gateway_canSendAgain"), List.of("eventGateway_afterSendingAgain"), "eventSubProcess_errorHandling", null, List.of());
+        public static final BpmnRelations SERVICE_TASK_SEND_MAIL_AGAIN = new BpmnRelations(null, List.of("gateway_canSendAgain"), List.of("eventGateway_afterSendingAgain"), "eventSubProcess_errorHandling", null, List.of(), "SERVICE_TASK");
 
-        public static final BpmnRelations SERVICE_TASK_SEND_TO_SUBSCRIBER = new BpmnRelations(null, List.of("gateway_hasSubscribers"), List.of("serviceTask_notifyAuthor"), null, null, List.of());
+        public static final BpmnRelations SERVICE_TASK_SEND_TO_SUBSCRIBER = new BpmnRelations(null, List.of("gateway_hasSubscribers"), List.of("serviceTask_notifyAuthor"), null, null, List.of(), "SERVICE_TASK");
 
-        public static final BpmnRelations START_EVENT_EDITION_CREATED = new BpmnRelations(null, List.of(), List.of("serviceTask_loadSubscribers"), null, null, List.of());
+        public static final BpmnRelations START_EVENT_EDITION_CREATED = new BpmnRelations(null, List.of(), List.of("serviceTask_loadSubscribers"), null, null, List.of(), "START_EVENT");
 
-        public static final BpmnRelations TIMER_NO_REJECTION_FOR_ONE_DAY = new BpmnRelations(null, List.of("eventGateway_afterSendingAgain"), List.of("endEvent_issueResolved"), "eventSubProcess_errorHandling", null, List.of());
+        public static final BpmnRelations TIMER_NO_REJECTION_FOR_ONE_DAY = new BpmnRelations(null, List.of("eventGateway_afterSendingAgain"), List.of("endEvent_issueResolved"), "eventSubProcess_errorHandling", null, List.of(), "TIMER_INTERMEDIATE_CATCH_EVENT");
       }
     }
   }

--- a/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
@@ -221,7 +221,7 @@ object SendNewsletterProcessApi {
       }
 
       /**
-       * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).
+       * Per-element graph metadata (elementType / previousElements / followingElements / parentId / boundary attachments).
        * Intended for tooling and tests, not worker runtime code.
        */
       object Relations {
@@ -231,6 +231,7 @@ object SendNewsletterProcessApi {
               parentId = null,
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "END_EVENT",
             )
 
         val END_EVENT_ISSUE_RESOLVED: BpmnRelations = BpmnRelations(
@@ -239,6 +240,7 @@ object SendNewsletterProcessApi {
               parentId = "eventSubProcess_errorHandling",
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "END_EVENT",
             )
 
         val END_EVENT_NO_SUBSCRIBERS: BpmnRelations = BpmnRelations(
@@ -247,6 +249,7 @@ object SendNewsletterProcessApi {
               parentId = null,
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "END_EVENT",
             )
 
         val ESCALATION_END_EVENT_NOFITY_SUPPORT: BpmnRelations = BpmnRelations(
@@ -255,6 +258,7 @@ object SendNewsletterProcessApi {
               parentId = "eventSubProcess_errorHandling",
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "ESCALATION_END_EVENT",
             )
 
         val ESCALATION_END_EVENT_NOFITY_SUPPORT_AFTER_REPEATED_ERROR: BpmnRelations =
@@ -264,6 +268,7 @@ object SendNewsletterProcessApi {
               parentId = "eventSubProcess_errorHandling",
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "END_EVENT",
             )
 
         val EVENT_GATEWAY_AFTER_SENDING_AGAIN: BpmnRelations = BpmnRelations(
@@ -272,6 +277,7 @@ object SendNewsletterProcessApi {
               parentId = "eventSubProcess_errorHandling",
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "EVENT_BASED_GATEWAY",
             )
 
         val EVENT_SUB_PROCESS_ERROR_HANDLING: BpmnRelations = BpmnRelations(
@@ -280,6 +286,7 @@ object SendNewsletterProcessApi {
               parentId = null,
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "SUB_PROCESS",
             )
 
         val EVENT_MAIL_REJECTED: BpmnRelations = BpmnRelations(
@@ -288,6 +295,7 @@ object SendNewsletterProcessApi {
               parentId = "eventSubProcess_errorHandling",
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "MESSAGE_START_EVENT",
             )
 
         val EVENT_MAIL_REJECTED_AGAIN: BpmnRelations = BpmnRelations(
@@ -296,6 +304,7 @@ object SendNewsletterProcessApi {
               parentId = "eventSubProcess_errorHandling",
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "MESSAGE_INTERMEDIATE_CATCH_EVENT",
             )
 
         val GATEWAY_CAN_SEND_AGAIN: BpmnRelations = BpmnRelations(
@@ -304,6 +313,7 @@ object SendNewsletterProcessApi {
               parentId = "eventSubProcess_errorHandling",
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "EXCLUSIVE_GATEWAY",
             )
 
         val GATEWAY_HAS_SUBSCRIBERS: BpmnRelations = BpmnRelations(
@@ -312,6 +322,7 @@ object SendNewsletterProcessApi {
               parentId = null,
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "EXCLUSIVE_GATEWAY",
             )
 
         val SERVICE_TASK_ANALYZE_ERROR: BpmnRelations = BpmnRelations(
@@ -320,6 +331,7 @@ object SendNewsletterProcessApi {
               parentId = "eventSubProcess_errorHandling",
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "SERVICE_TASK",
             )
 
         val SERVICE_TASK_LOAD_SUBSCRIBERS: BpmnRelations = BpmnRelations(
@@ -328,6 +340,7 @@ object SendNewsletterProcessApi {
               parentId = null,
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "SERVICE_TASK",
             )
 
         val SERVICE_TASK_NOTIFY_AUTHOR: BpmnRelations = BpmnRelations(
@@ -336,6 +349,7 @@ object SendNewsletterProcessApi {
               parentId = null,
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "SERVICE_TASK",
             )
 
         val SERVICE_TASK_SEND_MAIL_AGAIN: BpmnRelations = BpmnRelations(
@@ -344,6 +358,7 @@ object SendNewsletterProcessApi {
               parentId = "eventSubProcess_errorHandling",
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "SERVICE_TASK",
             )
 
         val SERVICE_TASK_SEND_TO_SUBSCRIBER: BpmnRelations = BpmnRelations(
@@ -352,6 +367,7 @@ object SendNewsletterProcessApi {
               parentId = null,
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "SERVICE_TASK",
             )
 
         val START_EVENT_EDITION_CREATED: BpmnRelations = BpmnRelations(
@@ -360,6 +376,7 @@ object SendNewsletterProcessApi {
               parentId = null,
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "START_EVENT",
             )
 
         val TIMER_NO_REJECTION_FOR_ONE_DAY: BpmnRelations = BpmnRelations(
@@ -368,6 +385,7 @@ object SendNewsletterProcessApi {
               parentId = "eventSubProcess_errorHandling",
               attachedToRef = null,
               attachedElements = emptyList(),
+              elementType = "TIMER_INTERMEDIATE_CATCH_EVENT",
             )
       }
     }

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
@@ -184,42 +184,42 @@ public final class NewsletterSubscriptionProcessApi {
   }
 
   /**
-   * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).
+   * Per-element graph metadata (elementType / previousElements / followingElements / parentId / boundary attachments).
    * Intended for tooling and tests, not worker runtime code.
    */
   public static final class Relations {
-    public static final BpmnRelations ACTIVITY_CONFIRM_REGISTRATION = new BpmnRelations("Confirm registration", List.of("Activity_SendConfirmationMail"), List.of("EndEvent_SubscriptionConfirmed"), "SubProcess_Confirmation", null, List.of("Timer_EveryDay"));
+    public static final BpmnRelations ACTIVITY_CONFIRM_REGISTRATION = new BpmnRelations("Confirm registration", List.of("Activity_SendConfirmationMail"), List.of("EndEvent_SubscriptionConfirmed"), "SubProcess_Confirmation", null, List.of("Timer_EveryDay"), "RECEIVE_TASK");
 
-    public static final BpmnRelations ACTIVITY_SEND_CONFIRMATION_MAIL = new BpmnRelations(null, List.of("StartEvent_RequestReceived", "Timer_EveryDay"), List.of("Activity_ConfirmRegistration"), "SubProcess_Confirmation", null, List.of());
+    public static final BpmnRelations ACTIVITY_SEND_CONFIRMATION_MAIL = new BpmnRelations(null, List.of("StartEvent_RequestReceived", "Timer_EveryDay"), List.of("Activity_ConfirmRegistration"), "SubProcess_Confirmation", null, List.of(), "SERVICE_TASK");
 
-    public static final BpmnRelations ACTIVITY_SEND_WELCOME_MAIL = new BpmnRelations(null, List.of("SubProcess_Confirmation"), List.of("EndEvent_RegistrationCompleted"), null, null, List.of());
+    public static final BpmnRelations ACTIVITY_SEND_WELCOME_MAIL = new BpmnRelations(null, List.of("SubProcess_Confirmation"), List.of("EndEvent_RegistrationCompleted"), null, null, List.of(), "SERVICE_TASK");
 
-    public static final BpmnRelations CALL_ACTIVITY_ABORT_REGISTRATION = new BpmnRelations(null, List.of("Timer_After3Days"), List.of("CompensationEndEvent_RegistrationAborted"), null, null, List.of());
+    public static final BpmnRelations CALL_ACTIVITY_ABORT_REGISTRATION = new BpmnRelations(null, List.of("Timer_After3Days"), List.of("CompensationEndEvent_RegistrationAborted"), null, null, List.of(), "CALL_ACTIVITY");
 
-    public static final BpmnRelations COMPENSATION_END_EVENT_REGISTRATION_ABORTED = new BpmnRelations(null, List.of("CallActivity_AbortRegistration"), List.of(), null, null, List.of());
+    public static final BpmnRelations COMPENSATION_END_EVENT_REGISTRATION_ABORTED = new BpmnRelations(null, List.of("CallActivity_AbortRegistration"), List.of(), null, null, List.of(), "COMPENSATION_END_EVENT");
 
-    public static final BpmnRelations COMPENSATION_EVENT_ON_SUBSCRIPTION_COUNTER = new BpmnRelations(null, List.of(), List.of(), null, "serviceTask_incrementSubscriptionCounter", List.of());
+    public static final BpmnRelations COMPENSATION_EVENT_ON_SUBSCRIPTION_COUNTER = new BpmnRelations(null, List.of(), List.of(), null, "serviceTask_incrementSubscriptionCounter", List.of(), "COMPENSATION_BOUNDARY_EVENT");
 
-    public static final BpmnRelations COMPENSATION_TASK_DECREMENT_SUBSCRIPTION_COUNTER = new BpmnRelations(null, List.of(), List.of(), null, null, List.of());
+    public static final BpmnRelations COMPENSATION_TASK_DECREMENT_SUBSCRIPTION_COUNTER = new BpmnRelations(null, List.of(), List.of(), null, null, List.of(), "TASK");
 
-    public static final BpmnRelations END_EVENT_REGISTRATION_COMPLETED = new BpmnRelations(null, List.of("Activity_SendWelcomeMail"), List.of(), null, null, List.of());
+    public static final BpmnRelations END_EVENT_REGISTRATION_COMPLETED = new BpmnRelations(null, List.of("Activity_SendWelcomeMail"), List.of(), null, null, List.of(), "END_EVENT");
 
-    public static final BpmnRelations END_EVENT_REGISTRATION_NOT_POSSIBLE = new BpmnRelations(null, List.of("ErrorEvent_InvalidMail"), List.of(), null, null, List.of());
+    public static final BpmnRelations END_EVENT_REGISTRATION_NOT_POSSIBLE = new BpmnRelations(null, List.of("ErrorEvent_InvalidMail"), List.of(), null, null, List.of(), "SIGNAL_END_EVENT");
 
-    public static final BpmnRelations END_EVENT_SUBSCRIPTION_CONFIRMED = new BpmnRelations(null, List.of("Activity_ConfirmRegistration"), List.of(), "SubProcess_Confirmation", null, List.of());
+    public static final BpmnRelations END_EVENT_SUBSCRIPTION_CONFIRMED = new BpmnRelations(null, List.of("Activity_ConfirmRegistration"), List.of(), "SubProcess_Confirmation", null, List.of(), "END_EVENT");
 
-    public static final BpmnRelations ERROR_EVENT_INVALID_MAIL = new BpmnRelations(null, List.of(), List.of("EndEvent_RegistrationNotPossible"), null, "SubProcess_Confirmation", List.of());
+    public static final BpmnRelations ERROR_EVENT_INVALID_MAIL = new BpmnRelations(null, List.of(), List.of("EndEvent_RegistrationNotPossible"), null, "SubProcess_Confirmation", List.of(), "ERROR_BOUNDARY_EVENT");
 
-    public static final BpmnRelations START_EVENT_REQUEST_RECEIVED = new BpmnRelations(null, List.of(), List.of("Activity_SendConfirmationMail"), "SubProcess_Confirmation", null, List.of());
+    public static final BpmnRelations START_EVENT_REQUEST_RECEIVED = new BpmnRelations(null, List.of(), List.of("Activity_SendConfirmationMail"), "SubProcess_Confirmation", null, List.of(), "START_EVENT");
 
-    public static final BpmnRelations START_EVENT_SUBMIT_REGISTRATION_FORM = new BpmnRelations(null, List.of(), List.of("serviceTask_incrementSubscriptionCounter"), null, null, List.of());
+    public static final BpmnRelations START_EVENT_SUBMIT_REGISTRATION_FORM = new BpmnRelations(null, List.of(), List.of("serviceTask_incrementSubscriptionCounter"), null, null, List.of(), "MESSAGE_START_EVENT");
 
-    public static final BpmnRelations SUB_PROCESS_CONFIRMATION = new BpmnRelations(null, List.of("serviceTask_incrementSubscriptionCounter"), List.of("Activity_SendWelcomeMail"), null, null, List.of("ErrorEvent_InvalidMail", "Timer_After3Days"));
+    public static final BpmnRelations SUB_PROCESS_CONFIRMATION = new BpmnRelations(null, List.of("serviceTask_incrementSubscriptionCounter"), List.of("Activity_SendWelcomeMail"), null, null, List.of("ErrorEvent_InvalidMail", "Timer_After3Days"), "SUB_PROCESS");
 
-    public static final BpmnRelations TIMER_AFTER_3_DAYS = new BpmnRelations(null, List.of(), List.of("CallActivity_AbortRegistration"), null, "SubProcess_Confirmation", List.of());
+    public static final BpmnRelations TIMER_AFTER_3_DAYS = new BpmnRelations(null, List.of(), List.of("CallActivity_AbortRegistration"), null, "SubProcess_Confirmation", List.of(), "TIMER_BOUNDARY_EVENT");
 
-    public static final BpmnRelations TIMER_EVERY_DAY = new BpmnRelations(null, List.of(), List.of("Activity_SendConfirmationMail"), "SubProcess_Confirmation", "Activity_ConfirmRegistration", List.of());
+    public static final BpmnRelations TIMER_EVERY_DAY = new BpmnRelations(null, List.of(), List.of("Activity_SendConfirmationMail"), "SubProcess_Confirmation", "Activity_ConfirmRegistration", List.of(), "TIMER_BOUNDARY_EVENT");
 
-    public static final BpmnRelations SERVICE_TASK_INCREMENT_SUBSCRIPTION_COUNTER = new BpmnRelations(null, List.of("StartEvent_SubmitRegistrationForm"), List.of("SubProcess_Confirmation"), null, null, List.of("CompensationEvent_OnSubscriptionCounter"));
+    public static final BpmnRelations SERVICE_TASK_INCREMENT_SUBSCRIPTION_COUNTER = new BpmnRelations(null, List.of("StartEvent_SubmitRegistrationForm"), List.of("SubProcess_Confirmation"), null, null, List.of("CompensationEvent_OnSubscriptionCounter"), "SERVICE_TASK");
   }
 }

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
@@ -246,7 +246,7 @@ object NewsletterSubscriptionProcessApi {
   }
 
   /**
-   * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).
+   * Per-element graph metadata (elementType / previousElements / followingElements / parentId / boundary attachments).
    * Intended for tooling and tests, not worker runtime code.
    */
   object Relations {
@@ -257,6 +257,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = "SubProcess_Confirmation",
           attachedToRef = null,
           attachedElements = listOf("Timer_EveryDay"),
+          elementType = "RECEIVE_TASK",
         )
 
     val ACTIVITY_SEND_CONFIRMATION_MAIL: BpmnRelations = BpmnRelations(
@@ -265,6 +266,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = "SubProcess_Confirmation",
           attachedToRef = null,
           attachedElements = emptyList(),
+          elementType = "SERVICE_TASK",
         )
 
     val ACTIVITY_SEND_WELCOME_MAIL: BpmnRelations = BpmnRelations(
@@ -273,6 +275,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = null,
           attachedToRef = null,
           attachedElements = emptyList(),
+          elementType = "SERVICE_TASK",
         )
 
     val CALL_ACTIVITY_ABORT_REGISTRATION: BpmnRelations = BpmnRelations(
@@ -281,6 +284,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = null,
           attachedToRef = null,
           attachedElements = emptyList(),
+          elementType = "CALL_ACTIVITY",
         )
 
     val COMPENSATION_END_EVENT_REGISTRATION_ABORTED: BpmnRelations = BpmnRelations(
@@ -289,6 +293,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = null,
           attachedToRef = null,
           attachedElements = emptyList(),
+          elementType = "COMPENSATION_END_EVENT",
         )
 
     val COMPENSATION_EVENT_ON_SUBSCRIPTION_COUNTER: BpmnRelations = BpmnRelations(
@@ -297,6 +302,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = null,
           attachedToRef = "serviceTask_incrementSubscriptionCounter",
           attachedElements = emptyList(),
+          elementType = "COMPENSATION_BOUNDARY_EVENT",
         )
 
     val COMPENSATION_TASK_DECREMENT_SUBSCRIPTION_COUNTER: BpmnRelations = BpmnRelations(
@@ -305,6 +311,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = null,
           attachedToRef = null,
           attachedElements = emptyList(),
+          elementType = "TASK",
         )
 
     val END_EVENT_REGISTRATION_COMPLETED: BpmnRelations = BpmnRelations(
@@ -313,6 +320,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = null,
           attachedToRef = null,
           attachedElements = emptyList(),
+          elementType = "END_EVENT",
         )
 
     val END_EVENT_REGISTRATION_NOT_POSSIBLE: BpmnRelations = BpmnRelations(
@@ -321,6 +329,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = null,
           attachedToRef = null,
           attachedElements = emptyList(),
+          elementType = "SIGNAL_END_EVENT",
         )
 
     val END_EVENT_SUBSCRIPTION_CONFIRMED: BpmnRelations = BpmnRelations(
@@ -329,6 +338,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = "SubProcess_Confirmation",
           attachedToRef = null,
           attachedElements = emptyList(),
+          elementType = "END_EVENT",
         )
 
     val ERROR_EVENT_INVALID_MAIL: BpmnRelations = BpmnRelations(
@@ -337,6 +347,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = null,
           attachedToRef = "SubProcess_Confirmation",
           attachedElements = emptyList(),
+          elementType = "ERROR_BOUNDARY_EVENT",
         )
 
     val START_EVENT_REQUEST_RECEIVED: BpmnRelations = BpmnRelations(
@@ -345,6 +356,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = "SubProcess_Confirmation",
           attachedToRef = null,
           attachedElements = emptyList(),
+          elementType = "START_EVENT",
         )
 
     val START_EVENT_SUBMIT_REGISTRATION_FORM: BpmnRelations = BpmnRelations(
@@ -353,6 +365,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = null,
           attachedToRef = null,
           attachedElements = emptyList(),
+          elementType = "MESSAGE_START_EVENT",
         )
 
     val SUB_PROCESS_CONFIRMATION: BpmnRelations = BpmnRelations(
@@ -361,6 +374,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = null,
           attachedToRef = null,
           attachedElements = listOf("ErrorEvent_InvalidMail", "Timer_After3Days"),
+          elementType = "SUB_PROCESS",
         )
 
     val TIMER_AFTER_3_DAYS: BpmnRelations = BpmnRelations(
@@ -369,6 +383,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = null,
           attachedToRef = "SubProcess_Confirmation",
           attachedElements = emptyList(),
+          elementType = "TIMER_BOUNDARY_EVENT",
         )
 
     val TIMER_EVERY_DAY: BpmnRelations = BpmnRelations(
@@ -377,6 +392,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = "SubProcess_Confirmation",
           attachedToRef = "Activity_ConfirmRegistration",
           attachedElements = emptyList(),
+          elementType = "TIMER_BOUNDARY_EVENT",
         )
 
     val SERVICE_TASK_INCREMENT_SUBSCRIPTION_COUNTER: BpmnRelations = BpmnRelations(
@@ -385,6 +401,7 @@ object NewsletterSubscriptionProcessApi {
           parentId = null,
           attachedToRef = null,
           attachedElements = listOf("CompensationEvent_OnSubscriptionCounter"),
+          elementType = "SERVICE_TASK",
         )
   }
 }

--- a/bpmn-to-code-runtime/src/main/kotlin/io/miragon/bpmn/runtime/BpmnRelations.kt
+++ b/bpmn-to-code-runtime/src/main/kotlin/io/miragon/bpmn/runtime/BpmnRelations.kt
@@ -9,6 +9,8 @@ package io.miragon.bpmn.runtime
  * @param parentId Id of the containing subprocess, or null if top-level.
  * @param attachedToRef For boundary events: id of the host element; null otherwise.
  * @param attachedElements Ids of boundary events attached to this element; empty when none.
+ * @param elementType The element's BPMN type, e.g. `SERVICE_TASK`, `EXCLUSIVE_GATEWAY`,
+ *   `TIMER_BOUNDARY_EVENT`; matches the value in the JSON export. `UNKNOWN` if unresolved.
  */
 data class BpmnRelations(
     val name: String? = null,
@@ -17,4 +19,5 @@ data class BpmnRelations(
     val parentId: String?,
     val attachedToRef: String?,
     val attachedElements: List<String>,
+    val elementType: String = "UNKNOWN",
 )

--- a/bpmn-to-code-runtime/src/test/kotlin/io/miragon/bpmn/runtime/RuntimeTypesTest.kt
+++ b/bpmn-to-code-runtime/src/test/kotlin/io/miragon/bpmn/runtime/RuntimeTypesTest.kt
@@ -58,10 +58,12 @@ class RuntimeTypesTest {
             parentId = null,
             attachedToRef = null,
             attachedElements = listOf("boundary-timer"),
+            elementType = "USER_TASK",
         )
         assertThat(relations.previousElements).containsExactly("start")
         assertThat(relations.followingElements).containsExactly("end")
         assertThat(relations.attachedElements).containsExactly("boundary-timer")
+        assertThat(relations.elementType).isEqualTo("USER_TASK")
     }
 
     @Test

--- a/docs/guide/generated-api.md
+++ b/docs/guide/generated-api.md
@@ -20,7 +20,7 @@ The generated Process API is an `object` (Kotlin) or `class` (Java) with nested 
 | `Signals` | Signal names from signal events |
 | `Variables` | Per-element variables, split into `Inputs` / `Outputs` sub-objects by direction |
 | `Flows` | Sequence flows with `sourceRef`, `targetRef`, `conditionExpression`, `isDefault` |
-| `Relations` | Per-element topology: `incoming`, `outgoing`, `parentId`, `attachedToRef`, `attachedElements` |
+| `Relations` | Per-element topology: `elementType`, `previousElements`, `followingElements`, `parentId`, `attachedToRef`, `attachedElements` |
 
 Sections are only included when the BPMN model contains matching elements.
 
@@ -128,11 +128,13 @@ object NewsletterSubscriptionProcessApi {
 
   object Relations {
     val ACTIVITY_CONFIRM_REGISTRATION: BpmnRelations = BpmnRelations(
-      incoming = listOf("Activity_SendConfirmationMail"),
-      outgoing = listOf("EndEvent_SubscriptionConfirmed"),
+      name = "Confirm registration",
+      previousElements = listOf("Activity_SendConfirmationMail"),
+      followingElements = listOf("EndEvent_SubscriptionConfirmed"),
       parentId = "SubProcess_Confirmation",
       attachedToRef = null,
       attachedElements = listOf("Timer_EveryDay"),
+      elementType = "RECEIVE_TASK",
     )
     // ... all elements
   }
@@ -191,11 +193,13 @@ The `Relations` section maps every flow node to its topology information via `Bp
 
 ```kotlin
 data class BpmnRelations(
-    val incoming: List<String>,      // IDs of incoming sequence flows or elements
-    val outgoing: List<String>,      // IDs of outgoing sequence flows or elements
-    val parentId: String?,           // parent subprocess ID, if any
-    val attachedToRef: String?,      // element this boundary event is attached to
-    val attachedElements: List<String>, // boundary events attached to this element
+    val name: String? = null,            // display name of the element, if set
+    val previousElements: List<String>,  // element IDs of preceding flow nodes
+    val followingElements: List<String>, // element IDs of following flow nodes
+    val parentId: String?,               // parent subprocess ID, if any
+    val attachedToRef: String?,          // element this boundary event is attached to
+    val attachedElements: List<String>,  // boundary events attached to this element
+    val elementType: String = "UNKNOWN", // BPMN type, e.g. SERVICE_TASK, TIMER_BOUNDARY_EVENT
 )
 ```
 


### PR DESCRIPTION
Closes #22. Builds on #21 (concrete event types in JSON) and #25 (two-axis `BpmnNodeType`).

## What
Every flow node's `BpmnRelations` now carries an `elementType`, so a Process API consumer no longer has to guess the element kind from the name.

```kotlin
val ACTIVITY_CONFIRM_REGISTRATION = BpmnRelations(
  name = "Confirm registration",
  previousElements = listOf("Activity_SendConfirmationMail"),
  followingElements = listOf("EndEvent_SubscriptionConfirmed"),
  parentId = "SubProcess_Confirmation",
  attachedToRef = null,
  attachedElements = listOf("Timer_EveryDay"),
  elementType = "RECEIVE_TASK",   // <-- new
)
```

## Decision: `String`, not an enum
Confirmed with the issue author. `elementType: String` matches `BpmnRelations`' existing all-`String`/`List` fields, and the value is produced by the **same** renderer as the JSON export (`ElementTypeName.of(nodeType)`) → the two surfaces are byte-identical (`TIMER_BOUNDARY_EVENT`, `ERROR_BOUNDARY_EVENT`, `MESSAGE_START_EVENT`, …). An enum was rejected: a concrete one needs ~40–50 hand-maintained composite constants; a shape-only one would diverge from the JSON values.

## How
- **Runtime**: `BpmnRelations` gains `val elementType: String = "UNKNOWN"` — appended **last** with a default, additive for the generated API.
- **Renderer relocated**: `ElementTypeName` moved `adapter.outbound.json` → **`adapter.outbound.shared`** so the json and codegen adapters share it with **no adapter→adapter coupling** (`HexagonalArchitectureTest` passes).
- **Codegen**: both `ProcessApiBuilder`s emit `elementType` (Kotlin named / Java positional-last).
- **Fixtures/goldens** regenerated; **docs** updated (also fixed pre-existing staleness in `generated-api.md`).

## Breaking?
Additive for the **generated API** (new field, default) — the issue frames it as non-breaking, hence `feat(core):`. **Caveat for review:** adding a constructor param to the published `io.miragon:bpmn-to-code-runtime` `BpmnRelations` data class is technically a **binary-incompatible** change (old compiled code calling the 6-arg constructor won't link until regenerated/recompiled). If we want to signal that, retag as `feat(runtime)!` before merge. Draft so we can settle this.

## Tests (all green)
`:bpmn-to-code-runtime:test`, `:bpmn-to-code-core:test` + `:detekt` (JSON goldens unchanged), `:bpmn-to-code-web:test`, `:bpmn-to-code-gradle:test`, `:bpmn-to-code-maven:test`.