### PR TITLE
ci(docker): sync README to Docker Hub on publish

### DIFF
--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -53,6 +53,15 @@ jobs:
         if: inputs.dry_run != true
         run: docker push miragon/bpmn-to-code-web:latest
 
+      - name: Update Docker Hub Description
+        if: inputs.dry_run != true
+        uses: peter-evans/dockerhub-description@432a30c9e07499fd01da9f8a49f0faf9e0ca5b77 # v4
+        with:
+          username: ${{ secrets.DOCKER_MIRAGON_USERNAME }}
+          password: ${{ secrets.DOCKER_MIRAGON_PASSWORD }}
+          repository: miragon/bpmn-to-code-web
+          readme-filepath: ./bpmn-to-code-web/README.md
+
       - name: Log out from Docker Hub
         if: always() && inputs.dry_run != true
         run: docker logout


### PR DESCRIPTION
Adds a `peter-evans/dockerhub-description` step to the Docker publish workflow so `bpmn-to-code-web/README.md` is automatically synced to the [Docker Hub overview](https://hub.docker.com/r/miragon/bpmn-to-code-web) on every release. Skipped on dry runs.