### PR TITLE
refactor(validation): rename ValidationContext to SingleModelValidationContext

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/service/BpmnValidationService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/service/BpmnValidationService.kt
@@ -5,7 +5,7 @@ import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.validation.BpmnValidationException
 import io.miragon.bpmn.domain.validation.model.Severity
 import io.miragon.bpmn.domain.validation.model.ValidationConfig
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationPhase
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 import io.miragon.bpmn.domain.validation.rules.CollisionDetectionRule
@@ -36,7 +36,7 @@ class BpmnValidationService(
             .filterNot { it.id in config.disabledRules }
 
         return models.flatMap { model ->
-            val ctx = ValidationContext(model, engine)
+            val ctx = SingleModelValidationContext(model, engine)
             activeRules.flatMap { it.validate(ctx) }
         }
     }

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/BpmnValidationRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/BpmnValidationRule.kt
@@ -1,7 +1,7 @@
 package io.miragon.bpmn.domain.validation
 
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationPhase
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
@@ -9,5 +9,5 @@ interface BpmnValidationRule {
     val id: String
     val severity: Severity
     val phase: ValidationPhase get() = ValidationPhase.PRE_MERGE
-    fun validate(context: ValidationContext): List<ValidationViolation>
+    fun validate(context: SingleModelValidationContext): List<ValidationViolation>
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/model/SingleModelValidationContext.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/model/SingleModelValidationContext.kt
@@ -1,0 +1,22 @@
+package io.miragon.bpmn.domain.validation.model
+
+import io.miragon.bpmn.domain.ProcessModel
+import io.miragon.bpmn.domain.shared.ProcessEngine
+
+/**
+ * Context handed to a validation rule. Carries the single process model under validation.
+ */
+data class SingleModelValidationContext(
+    val model: ProcessModel,
+    val engine: ProcessEngine,
+)
+
+/*
+ * Backward-compatibility alias for the previous type name. Kept as a temporary migration aid;
+ * scheduled for removal in v6.0.0. Migrate to [SingleModelValidationContext].
+ */
+@Deprecated(
+    message = "Renamed to SingleModelValidationContext; this alias will be removed in v6.0.0",
+    replaceWith = ReplaceWith("SingleModelValidationContext"),
+)
+typealias ValidationContext = SingleModelValidationContext

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/model/ValidationContext.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/model/ValidationContext.kt
@@ -1,9 +1,0 @@
-package io.miragon.bpmn.domain.validation.model
-
-import io.miragon.bpmn.domain.ProcessModel
-import io.miragon.bpmn.domain.shared.ProcessEngine
-
-data class ValidationContext(
-    val model: ProcessModel,
-    val engine: ProcessEngine,
-)

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/CollisionDetectionRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/CollisionDetectionRule.kt
@@ -3,7 +3,7 @@ package io.miragon.bpmn.domain.validation.rules
 import io.miragon.bpmn.domain.service.CollisionDetectionService
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationPhase
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
@@ -15,7 +15,7 @@ class CollisionDetectionRule(
     override val severity = Severity.ERROR
     override val phase = ValidationPhase.POST_MERGE
 
-    override fun validate(context: ValidationContext): List<ValidationViolation> {
+    override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         val collisions = collisionDetectionService.findCollisions(context.model)
         return collisions.map { detail ->
             val conflicting = detail.conflictingIds.joinToString(", ")

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/EmptyProcessRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/EmptyProcessRule.kt
@@ -2,7 +2,7 @@ package io.miragon.bpmn.domain.validation.rules
 
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
 class EmptyProcessRule : BpmnValidationRule {
@@ -10,7 +10,7 @@ class EmptyProcessRule : BpmnValidationRule {
     override val id = "empty-process"
     override val severity = Severity.WARN
 
-    override fun validate(context: ValidationContext): List<ValidationViolation> {
+    override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         if (context.model.flowNodes.isEmpty()) {
             return listOf(
                 ValidationViolation(

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/EngineMismatchRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/EngineMismatchRule.kt
@@ -4,7 +4,7 @@ import io.miragon.bpmn.domain.BpmnModel
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
 /**
@@ -24,7 +24,7 @@ class EngineMismatchRule : BpmnValidationRule {
     override val id = "engine-mismatch"
     override val severity = Severity.ERROR
 
-    override fun validate(context: ValidationContext): List<ValidationViolation> {
+    override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         val detected = (context.model as? BpmnModel)?.detectedEngine
         val selected = context.engine
         val violation = when {
@@ -35,7 +35,7 @@ class EngineMismatchRule : BpmnValidationRule {
         return listOfNotNull(violation)
     }
 
-    private fun violation(context: ValidationContext, severity: Severity, message: String): ValidationViolation {
+    private fun violation(context: SingleModelValidationContext, severity: Severity, message: String): ValidationViolation {
         return ValidationViolation(
             ruleId = id,
             severity = severity,

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/InvalidIdentifierRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/InvalidIdentifierRule.kt
@@ -3,7 +3,7 @@ package io.miragon.bpmn.domain.validation.rules
 import io.miragon.bpmn.domain.shared.VariableMapping
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
 /**
@@ -16,7 +16,7 @@ class InvalidIdentifierRule : BpmnValidationRule {
 
     private val validIdentifier = Regex("^[A-Z_][A-Z0-9_]*$")
 
-    override fun validate(context: ValidationContext): List<ValidationViolation> {
+    override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         val model = context.model
         val violations = mutableListOf<ValidationViolation>()
         checkMappings(violations, model.processId, model.flowNodes, "FlowNode")

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingCalledElementRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingCalledElementRule.kt
@@ -2,7 +2,7 @@ package io.miragon.bpmn.domain.validation.rules
 
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
 class MissingCalledElementRule : BpmnValidationRule {
@@ -10,7 +10,7 @@ class MissingCalledElementRule : BpmnValidationRule {
     override val id = "missing-called-element"
     override val severity = Severity.ERROR
 
-    override fun validate(context: ValidationContext): List<ValidationViolation> {
+    override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         return context.model.callActivities
             .filter { !it.hasCalledElement() }
             .map { callActivity ->

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingElementIdRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingElementIdRule.kt
@@ -2,7 +2,7 @@ package io.miragon.bpmn.domain.validation.rules
 
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
 /**
@@ -16,7 +16,7 @@ class MissingElementIdRule : BpmnValidationRule {
     override val id = "missing-element-id"
     override val severity = Severity.ERROR
 
-    override fun validate(context: ValidationContext): List<ValidationViolation> {
+    override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         val model = context.model
         return model.flowNodes
             .filter { it.id == null }

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingErrorDefinitionRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingErrorDefinitionRule.kt
@@ -2,7 +2,7 @@ package io.miragon.bpmn.domain.validation.rules
 
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
 class MissingErrorDefinitionRule : BpmnValidationRule {
@@ -10,7 +10,7 @@ class MissingErrorDefinitionRule : BpmnValidationRule {
     override val id = "missing-error-definition"
     override val severity = Severity.ERROR
 
-    override fun validate(context: ValidationContext): List<ValidationViolation> {
+    override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         return context.model.errors
             .filter { !it.hasRequiredFields() }
             .map { error ->

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingMessageNameRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingMessageNameRule.kt
@@ -2,7 +2,7 @@ package io.miragon.bpmn.domain.validation.rules
 
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
 class MissingMessageNameRule : BpmnValidationRule {
@@ -10,7 +10,7 @@ class MissingMessageNameRule : BpmnValidationRule {
     override val id = "missing-message-name"
     override val severity = Severity.ERROR
 
-    override fun validate(context: ValidationContext): List<ValidationViolation> {
+    override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         return context.model.messages
             .filter { !it.hasName() }
             .map { message ->

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingProcessIdRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingProcessIdRule.kt
@@ -2,7 +2,7 @@ package io.miragon.bpmn.domain.validation.rules
 
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
 class MissingProcessIdRule : BpmnValidationRule {
@@ -10,7 +10,7 @@ class MissingProcessIdRule : BpmnValidationRule {
     override val id = "missing-process-id"
     override val severity = Severity.ERROR
 
-    override fun validate(context: ValidationContext): List<ValidationViolation> {
+    override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         if (context.model.processId.isBlank()) {
             return listOf(
                 ValidationViolation(

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingServiceTaskImplementationRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingServiceTaskImplementationRule.kt
@@ -3,7 +3,7 @@ package io.miragon.bpmn.domain.validation.rules
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
 class MissingServiceTaskImplementationRule : BpmnValidationRule {
@@ -11,7 +11,7 @@ class MissingServiceTaskImplementationRule : BpmnValidationRule {
     override val id = "missing-service-task-implementation"
     override val severity = Severity.ERROR
 
-    override fun validate(context: ValidationContext): List<ValidationViolation> {
+    override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         return context.model.serviceTasks
             .filter { !it.hasImplementation() }
             .map { task ->

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingSignalNameRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingSignalNameRule.kt
@@ -2,7 +2,7 @@ package io.miragon.bpmn.domain.validation.rules
 
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
 class MissingSignalNameRule : BpmnValidationRule {
@@ -10,7 +10,7 @@ class MissingSignalNameRule : BpmnValidationRule {
     override val id = "missing-signal-name"
     override val severity = Severity.ERROR
 
-    override fun validate(context: ValidationContext): List<ValidationViolation> {
+    override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         return context.model.signals
             .filter { !it.hasName() }
             .map {

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingTimerDefinitionRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingTimerDefinitionRule.kt
@@ -2,7 +2,7 @@ package io.miragon.bpmn.domain.validation.rules
 
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
 class MissingTimerDefinitionRule : BpmnValidationRule {
@@ -10,7 +10,7 @@ class MissingTimerDefinitionRule : BpmnValidationRule {
     override val id = "missing-timer-definition"
     override val severity = Severity.ERROR
 
-    override fun validate(context: ValidationContext): List<ValidationViolation> {
+    override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         return context.model.timers
             .filter { !it.hasTimerType() }
             .map { timer ->

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/TimerCronSyntaxRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/TimerCronSyntaxRule.kt
@@ -2,7 +2,7 @@ package io.miragon.bpmn.domain.validation.rules
 
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
 /**
@@ -17,7 +17,7 @@ class TimerCronSyntaxRule : BpmnValidationRule {
     override val id = "timer-cron-syntax"
     override val severity = Severity.ERROR
 
-    override fun validate(context: ValidationContext): List<ValidationViolation> {
+    override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         return context.model.timers.mapNotNull { timer ->
             val (type, value) = timer.getValue()
             if (type != "Cycle") return@mapNotNull null

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/TimerIso8601SyntaxRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/TimerIso8601SyntaxRule.kt
@@ -2,7 +2,7 @@ package io.miragon.bpmn.domain.validation.rules
 
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
 /**
@@ -16,7 +16,7 @@ class TimerIso8601SyntaxRule : BpmnValidationRule {
     override val id = "timer-iso8601-syntax"
     override val severity = Severity.ERROR
 
-    override fun validate(context: ValidationContext): List<ValidationViolation> {
+    override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         return context.model.timers.mapNotNull { timer ->
             val (type, value) = timer.getValue()
             if (value.isBlank() || TimerValueSyntax.isExpression(value)) return@mapNotNull null

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/CollisionDetectionRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/CollisionDetectionRuleTest.kt
@@ -4,7 +4,7 @@ import io.miragon.bpmn.domain.shared.FlowNodeDefinition
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.testBpmnModel
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationPhase
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -30,7 +30,7 @@ class CollisionDetectionRuleTest {
         )
 
         // when: validating
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
 
         // then: one error violation referencing conflicting IDs
         assertThat(violations).hasSize(1)
@@ -50,7 +50,7 @@ class CollisionDetectionRuleTest {
         )
 
         // when / then: no violations
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/EmptyProcessRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/EmptyProcessRuleTest.kt
@@ -4,7 +4,7 @@ import io.miragon.bpmn.domain.shared.FlowNodeDefinition
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.testBpmnModel
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -19,7 +19,7 @@ class EmptyProcessRuleTest {
         val model = testBpmnModel(flowNodes = emptyList())
 
         // when / then: a WARN violation is reported
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.WARN)
     }
@@ -33,7 +33,7 @@ class EmptyProcessRuleTest {
         )
 
         // when / then: no violations
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/EngineMismatchRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/EngineMismatchRuleTest.kt
@@ -3,7 +3,7 @@ package io.miragon.bpmn.domain.validation.rules
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.testBpmnModel
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -18,7 +18,7 @@ class EngineMismatchRuleTest {
         val model = testBpmnModel(detectedEngine = ProcessEngine.CAMUNDA_7)
 
         // when / then: a single engine-mismatch ERROR is produced
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.OPERATON))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.OPERATON))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].ruleId).isEqualTo("engine-mismatch")
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
@@ -32,7 +32,7 @@ class EngineMismatchRuleTest {
         val model = testBpmnModel(detectedEngine = ProcessEngine.ZEEBE)
 
         // when / then: no violation is reported
-        assertThat(underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))).isEmpty()
+        assertThat(underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))).isEmpty()
     }
 
     @Test
@@ -42,7 +42,7 @@ class EngineMismatchRuleTest {
         val model = testBpmnModel(detectedEngine = null)
 
         // when / then: a single engine-mismatch WARN is produced
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.CAMUNDA_7))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.CAMUNDA_7))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].ruleId).isEqualTo("engine-mismatch")
         assertThat(violations[0].severity).isEqualTo(Severity.WARN)

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/InvalidIdentifierRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/InvalidIdentifierRuleTest.kt
@@ -9,7 +9,7 @@ import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.shared.TimerDefinition
 import io.miragon.bpmn.domain.testBpmnModel
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -26,7 +26,7 @@ class InvalidIdentifierRuleTest {
         )
 
         // when: validating
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
 
         // then: a WARN violation mentioning "invalid identifier"
         assertThat(violations).hasSize(1)
@@ -48,7 +48,7 @@ class InvalidIdentifierRuleTest {
         )
 
         // when: validating
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
 
         // then: two WARN violations — one for FlowNode, one for Timer (same underlying id)
         assertThat(violations).hasSize(2)
@@ -65,7 +65,7 @@ class InvalidIdentifierRuleTest {
         )
 
         // when: validating
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
 
         // then: a WARN violation mentioning "invalid identifier"
         assertThat(violations).hasSize(1)
@@ -82,7 +82,7 @@ class InvalidIdentifierRuleTest {
         )
 
         // when: validating
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
 
         // then: a WARN violation mentioning "invalid identifier"
         assertThat(violations).hasSize(1)
@@ -99,7 +99,7 @@ class InvalidIdentifierRuleTest {
         )
 
         // when / then: no violations
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 
@@ -117,7 +117,7 @@ class InvalidIdentifierRuleTest {
         )
 
         // when / then: no violations
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingCalledElementRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingCalledElementRuleTest.kt
@@ -6,7 +6,7 @@ import io.miragon.bpmn.domain.shared.FlowNodeProperties
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.testBpmnModel
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -28,7 +28,7 @@ class MissingCalledElementRuleTest {
         )
 
         // when / then: an ERROR violation is reported
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
     }
@@ -47,7 +47,7 @@ class MissingCalledElementRuleTest {
         )
 
         // when / then: no violations
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingElementIdRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingElementIdRuleTest.kt
@@ -4,7 +4,7 @@ import io.miragon.bpmn.domain.shared.FlowNodeDefinition
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.testBpmnModel
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -21,7 +21,7 @@ class MissingElementIdRuleTest {
         )
 
         // when / then: an ERROR violation mentioning "FlowNode has no ID"
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
         assertThat(violations[0].message).contains("FlowNode has no ID")
@@ -36,7 +36,7 @@ class MissingElementIdRuleTest {
         )
 
         // when / then: no violations
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingErrorDefinitionRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingErrorDefinitionRuleTest.kt
@@ -4,7 +4,7 @@ import io.miragon.bpmn.domain.shared.ErrorDefinition
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.testBpmnModel
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -21,7 +21,7 @@ class MissingErrorDefinitionRuleTest {
         )
 
         // when / then: an ERROR violation is reported
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
     }
@@ -35,7 +35,7 @@ class MissingErrorDefinitionRuleTest {
         )
 
         // when / then: a violation is reported
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
     }
 
@@ -48,7 +48,7 @@ class MissingErrorDefinitionRuleTest {
         )
 
         // when / then: no violations
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingMessageNameRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingMessageNameRuleTest.kt
@@ -4,7 +4,7 @@ import io.miragon.bpmn.domain.shared.MessageDefinition
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.testBpmnModel
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -21,7 +21,7 @@ class MissingMessageNameRuleTest {
         )
 
         // when / then: an ERROR violation is reported for the message element
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
         assertThat(violations[0].elementId).isEqualTo("msg1")
@@ -36,7 +36,7 @@ class MissingMessageNameRuleTest {
         )
 
         // when / then: no violations
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingProcessIdRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingProcessIdRuleTest.kt
@@ -3,7 +3,7 @@ package io.miragon.bpmn.domain.validation.rules
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.testBpmnModel
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -18,7 +18,7 @@ class MissingProcessIdRuleTest {
         val model = testBpmnModel(processId = "")
 
         // when / then: an ERROR violation is reported
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
     }
@@ -30,7 +30,7 @@ class MissingProcessIdRuleTest {
         val model = testBpmnModel(processId = "my-process")
 
         // when / then: no violations
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingServiceTaskImplementationRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingServiceTaskImplementationRuleTest.kt
@@ -7,7 +7,7 @@ import io.miragon.bpmn.domain.shared.ServiceTaskDefinition
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL_VALUE_KEY
 import io.miragon.bpmn.domain.testBpmnModel
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -29,7 +29,7 @@ class MissingServiceTaskImplementationRuleTest {
         )
 
         // when: validating against Zeebe
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
 
         // then: an ERROR violation mentioning zeebe:taskDefinition
         assertThat(violations).hasSize(1)
@@ -54,7 +54,7 @@ class MissingServiceTaskImplementationRuleTest {
         )
 
         // when / then: no violations (for any engine)
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.CAMUNDA_7))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.CAMUNDA_7))
         assertThat(violations).isEmpty()
     }
 
@@ -72,7 +72,7 @@ class MissingServiceTaskImplementationRuleTest {
         )
 
         // when / then: the violation message mentions camunda:topic
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.CAMUNDA_7))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.CAMUNDA_7))
         assertThat(violations[0].message).contains("camunda:topic")
     }
 
@@ -90,7 +90,7 @@ class MissingServiceTaskImplementationRuleTest {
         )
 
         // when / then: the violation message mentions operaton:topic
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.OPERATON))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.OPERATON))
         assertThat(violations[0].message).contains("operaton:topic")
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingSignalNameRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingSignalNameRuleTest.kt
@@ -4,7 +4,7 @@ import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.shared.SignalDefinition
 import io.miragon.bpmn.domain.testBpmnModel
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -21,7 +21,7 @@ class MissingSignalNameRuleTest {
         )
 
         // when / then: an ERROR violation is reported
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
     }
@@ -35,7 +35,7 @@ class MissingSignalNameRuleTest {
         )
 
         // when / then: no violations
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingTimerDefinitionRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MissingTimerDefinitionRuleTest.kt
@@ -6,7 +6,7 @@ import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.shared.TimerDefinition
 import io.miragon.bpmn.domain.testBpmnModel
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -28,7 +28,7 @@ class MissingTimerDefinitionRuleTest {
         )
 
         // when / then: an ERROR violation is reported
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
     }
@@ -47,7 +47,7 @@ class MissingTimerDefinitionRuleTest {
         )
 
         // when / then: no violations
-        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/TimerCronSyntaxRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/TimerCronSyntaxRuleTest.kt
@@ -6,7 +6,7 @@ import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.shared.TimerDefinition
 import io.miragon.bpmn.domain.testBpmnModel
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -61,6 +61,6 @@ class TimerCronSyntaxRuleTest {
                 ),
             ),
         )
-        return underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        return underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/TimerIso8601SyntaxRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/TimerIso8601SyntaxRuleTest.kt
@@ -6,7 +6,7 @@ import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.shared.TimerDefinition
 import io.miragon.bpmn.domain.testBpmnModel
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -68,6 +68,6 @@ class TimerIso8601SyntaxRuleTest {
                 ),
             ),
         )
-        return underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+        return underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
     }
 }

--- a/bpmn-to-code-testing/src/main/kotlin/io/miragon/bpmn/testing/BpmnValidator.kt
+++ b/bpmn-to-code-testing/src/main/kotlin/io/miragon/bpmn/testing/BpmnValidator.kt
@@ -7,7 +7,7 @@ import io.miragon.bpmn.domain.service.ModelMergerService
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationPhase
 import io.miragon.bpmn.domain.validation.ValidationResult
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
@@ -112,7 +112,7 @@ class BpmnValidator private constructor(
         val postMergeRules = activeRules.filter { it.phase == ValidationPhase.POST_MERGE }
 
         val preMergeViolations = models.flatMap { model ->
-            val ctx = ValidationContext(model, engine)
+            val ctx = SingleModelValidationContext(model, engine)
             val violations = preMergeRules.flatMap { it.validate(ctx) }
             applyPolicy(violations)
         }
@@ -123,7 +123,7 @@ class BpmnValidator private constructor(
 
         val mergedModels = ModelMergerService().mergeModels(models)
         val postMergeViolations = mergedModels.flatMap { merged ->
-            val ctx = ValidationContext(merged, engine)
+            val ctx = SingleModelValidationContext(merged, engine)
             val violations = postMergeRules.flatMap { it.validate(ctx) }
             applyPolicy(violations)
         }

--- a/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/BpmnProcessArchitectureTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/BpmnProcessArchitectureTest.kt
@@ -3,7 +3,7 @@ package io.miragon.bpmn.testing
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationPhase
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 import org.assertj.core.api.Assertions.assertThat
@@ -23,7 +23,7 @@ class BpmnProcessArchitectureTest {
         override val severity = Severity.WARN
         override val phase = ValidationPhase.PRE_MERGE
 
-        override fun validate(context: ValidationContext): List<ValidationViolation> {
+        override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
             return context.model.serviceTasks
                 .filter { task ->
                     val name = task.id ?: ""

--- a/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/CallActivityInputRuleTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/CallActivityInputRuleTest.kt
@@ -3,7 +3,7 @@ package io.miragon.bpmn.testing
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -14,7 +14,7 @@ class CallActivityInputRuleTest {
         override val id = "call-activity-required-inputs"
         override val severity = Severity.ERROR
 
-        override fun validate(context: ValidationContext): List<ValidationViolation> {
+        override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
             return context.model.callActivities.flatMap { callActivity ->
                 val declaredTargets = callActivity.inputMappings.mapNotNull { it.target }.toSet()
                 (required - declaredTargets).map { missing ->
@@ -34,7 +34,7 @@ class CallActivityInputRuleTest {
         override val id = "call-activity-required-outputs"
         override val severity = Severity.ERROR
 
-        override fun validate(context: ValidationContext): List<ValidationViolation> {
+        override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
             return context.model.callActivities.flatMap { callActivity ->
                 val declaredTargets = callActivity.outputMappings.mapNotNull { it.target }.toSet()
                 (required - declaredTargets).map { missing ->

--- a/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/OutputExpressionRuleTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/OutputExpressionRuleTest.kt
@@ -4,7 +4,7 @@ import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.shared.VariableDirection
 import io.miragon.bpmn.domain.validation.BpmnValidationRule
 import io.miragon.bpmn.domain.validation.model.Severity
-import io.miragon.bpmn.domain.validation.model.ValidationContext
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -21,7 +21,7 @@ class OutputExpressionRuleTest {
         override val severity = Severity.ERROR
         private val allowed = Regex("""\$\{(null|true|false|execution\.getVariable\('[^']+'\))}""")
 
-        override fun validate(context: ValidationContext): List<ValidationViolation> {
+        override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
             return context.model.flowNodes
                 .flatMap { node -> node.variables.map { node to it } }
                 .filter { (_, variable) -> variable.direction == VariableDirection.OUTPUT }


### PR DESCRIPTION
## What & why

Preparatory refactor split out from the cross-process validation feature (#18): renames the single-model rule context type so the upcoming work can add a symmetric `CrossModelValidationContext` without a noisy mixed diff.

- `ValidationContext` → **`SingleModelValidationContext`** (data class + file).
- All references/imports updated across the built-in rules, `BpmnValidationService`, the testing `BpmnValidator`, and rule tests.
- A `@Deprecated typealias ValidationContext = SingleModelValidationContext` keeps existing rule **source** compiling (scheduled for removal in v6.0.0).

## Not in scope (stays in the feature PR #18 / #30)

The rule-interface rename (`BpmnValidationRule` → `SingleModelValidationRule`), the `ValidationRule` marker, and the new `CrossModelValidationRule` / `CrossModelValidationContext` are **not** here — this MR is the pure context rename only.

## Compatibility

No behavior change. Source-compatible via the deprecated alias; note that typealiases are compile-time only, so a precompiled artifact referencing `ValidationContext` would need recompiling. Committed as `refactor` (no release trigger on its own).

## Verification

`./gradlew :bpmn-to-code-core:test :bpmn-to-code-testing:test` — green.
