### PR TITLE
chore: release cross-process rules as 4.1.0 (non-breaking)

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/SingleModelValidationRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/SingleModelValidationRule.kt
@@ -11,10 +11,10 @@ interface SingleModelValidationRule : ValidationRule {
 
 /*
  * Backward-compatibility alias for the previous type name. Kept as a temporary migration aid;
- * scheduled for removal in v6.0.0. Migrate to [SingleModelValidationRule].
+ * scheduled for removal in v5.0.0. Migrate to [SingleModelValidationRule].
  */
 @Deprecated(
-    message = "Renamed to SingleModelValidationRule; this alias will be removed in v6.0.0",
+    message = "Renamed to SingleModelValidationRule; this alias will be removed in v5.0.0",
     replaceWith = ReplaceWith("SingleModelValidationRule"),
 )
 typealias BpmnValidationRule = SingleModelValidationRule

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/model/SingleModelValidationContext.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/model/SingleModelValidationContext.kt
@@ -15,10 +15,10 @@ data class SingleModelValidationContext(
 
 /*
  * Backward-compatibility alias for the previous type name. Kept as a temporary migration aid;
- * scheduled for removal in v6.0.0. Migrate to [SingleModelValidationContext].
+ * scheduled for removal in v5.0.0. Migrate to [SingleModelValidationContext].
  */
 @Deprecated(
-    message = "Renamed to SingleModelValidationContext; this alias will be removed in v6.0.0",
+    message = "Renamed to SingleModelValidationContext; this alias will be removed in v5.0.0",
     replaceWith = ReplaceWith("SingleModelValidationContext"),
 )
 typealias ValidationContext = SingleModelValidationContext

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -3,7 +3,7 @@
 Release notes for bpmn-to-code. New entries are added automatically by
 [release-please](https://github.com/googleapis/release-please) when a release PR is merged.
 
-- Moving to v5 (custom validation rule interface renamed; cross-process rules added)? See the [v5 Migration Guide](./v5).
+- Preparing for v5 (the deprecated `BpmnValidationRule` / `ValidationContext` aliases will be removed)? See the [v5 Migration Guide](./v5).
 - Upgrading to v4 (deprecated `io.github.emaarco` runtime types removed)? See the [v4 Migration Guide](./v4).
 - Moving to v3 (the `io.miragon` namespace)? See the [v3 Migration Guide](./v3).
 - Upgrading from v1? See the [v2 Migration Guide](./v2).

--- a/docs/changelog/v5.md
+++ b/docs/changelog/v5.md
@@ -1,30 +1,31 @@
-# v5.0.0 Migration Guide — validation rule interface renamed
+# v5.0.0 Migration Guide — deprecated rule aliases removed
 
-v5.0.0 renames the custom-rule interface and its context in the `bpmn-to-code-testing` module, to make
-room for **cross-process (multi-model) validation rules**. The old names remain as `@Deprecated`
-typealiases, so existing rule **source** keeps compiling after a recompile — this is a rename, not a
-behavior change. (Typealiases are compile-time only: any precompiled artifact linked against the old
-`BpmnValidationRule` / `ValidationContext` class names must be recompiled against v5.)
+::: info Upcoming release
+The rename below shipped as a **non-breaking** change in **4.1.0** — the old names were kept as
+`@Deprecated` typealiases. **v5.0.0 removes those aliases.** Nothing to do while you are on 4.1.x;
+migrate before upgrading to 5.0.0.
+:::
 
-The aliases are a migration aid, not a permanent surface — they are **scheduled for removal in v6.0.0**,
-so update your rules while they still compile.
+In 4.1.0 the custom-rule interface and its context in the `bpmn-to-code-testing` module were renamed to
+make room for [cross-process (multi-model) validation rules](/validate/testing#cross-process-multi-model-rules):
 
 - `BpmnValidationRule` → **`SingleModelValidationRule`**
 - `ValidationContext` → **`SingleModelValidationContext`**
-- New: **`CrossModelValidationRule`** + **`CrossModelValidationContext`** for rules that reason across
-  all loaded process models (e.g. resolving a call activity's called element to the called process).
+
+The old names stayed available as `@Deprecated` typealiases, so existing rules kept compiling. **v5.0.0
+removes them**, so any rule still using the old names must be updated first.
 
 ## Am I affected?
 
-Only if you wrote **custom validation rules** against `bpmn-to-code-testing`. Built-in rules
-(`BpmnRules.*`), the fluent `BpmnValidator` API, and assertions are unchanged.
+Only if you wrote **custom validation rules** and still reference `BpmnValidationRule` /
+`ValidationContext`. Built-in rules (`BpmnRules.*`), the fluent `BpmnValidator` API, and assertions are
+unaffected.
 
-If you use only built-in rules, there is nothing to do.
+If you already migrated to the new names (or only use built-in rules), there is nothing to do.
 
 ## Migrating
 
-Your existing rules still compile against the deprecated aliases. To clear the deprecation warnings,
-update the type references:
+Update the type references:
 
 ```kotlin
 // Before
@@ -51,37 +52,5 @@ import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 ```
 
 Everything else — `id`, `severity`, `phase`, `ValidationViolation`, and how you register rules via
-`withRules(...)` — is identical.
-
-## New: cross-process rules
-
-A `SingleModelValidationRule` sees one process at a time. For checks that span files — for example
-whether a call activity's called process actually exists among your models — implement
-`CrossModelValidationRule`. It is invoked once with a `CrossModelValidationContext` that carries all
-loaded models and can resolve cross-process references:
-
-```kotlin
-class CallActivityTargetExistsRule : CrossModelValidationRule {
-    override val id = "call-activity-target-exists"
-    override val severity = Severity.ERROR
-
-    override fun validate(context: CrossModelValidationContext): List<ValidationViolation> {
-        return context.models.flatMap { model ->
-            model.callActivities
-                .filter { it.hasCalledElement() && context.resolveCalledModel(it) == null }
-                .map { callActivity ->
-                    ValidationViolation(
-                        ruleId = id,
-                        severity = severity,
-                        elementId = callActivity.id,
-                        processId = model.processId,
-                        message = "Call activity '${callActivity.id}' references unknown process '${callActivity.getValue()}'.",
-                    )
-                }
-        }
-    }
-}
-```
-
-Cross-model rules go through the same `.withRules(...)` flow and can be mixed with single-model rules in
-one run. See the [testing module docs](/validate/testing#cross-process-multi-model-rules) for details.
+`withRules(...)` — is unchanged. The new `CrossModelValidationRule` / `CrossModelValidationContext`
+(added in 4.1.0) are unaffected by the removal.

--- a/docs/validate/testing.md
+++ b/docs/validate/testing.md
@@ -157,11 +157,12 @@ Cron and ISO-8601 are mutually exclusive for `timeCycle` timers, so enable **one
 Implement the `SingleModelValidationRule` interface to add project-specific checks. Each rule is
 invoked once per process model and sees a single model through its `SingleModelValidationContext`:
 
-::: warning Renamed in v5
+::: warning Renamed (deprecated since 4.1.0)
 `BpmnValidationRule` → `SingleModelValidationRule` and `ValidationContext` → `SingleModelValidationContext`
 (to contrast with the new [`CrossModelValidationRule`](#cross-process-multi-model-rules) /
-`CrossModelValidationContext`). The old names remain as deprecated typealiases, so existing rules keep
-compiling — update the type references at your convenience. See the [v5 migration guide](/changelog/v5).
+`CrossModelValidationContext`). The old names remain as deprecated typealiases — source-compatible, so
+existing rules keep compiling — and are **scheduled for removal in 5.0.0**. Update the type references at
+your convenience; see the [v5 migration guide](/changelog/v5).
 :::
 
 ```kotlin


### PR DESCRIPTION
## Why

The cross-process rules work (#30) landed as `feat(testing)!`, so release-please opened **#32 proposing 5.0.0**. But the interface/context renames keep `@Deprecated` typealiases → the change is **source-compatible**, i.e. a **minor**, not a breaking release. The breaking part (removing the aliases) is deferred to the next major.

Nothing is tagged yet (latest tag is v4.0.0), and the merged commit can't be edited (ruleset: `non_fast_forward` + `pull_request` + `required_signatures`), so this steers the release additively.

## What this does

- **`Release-As: 4.1.0`** trailer → release-please retargets #32 from 5.0.0 to **4.1.0**.
- Retargets the deprecation/removal notes from **v6.0.0 → v5.0.0** (aliases deprecated in 4.1.0, removed in the next major 5.0.0): the `@Deprecated` messages + KDoc on `SingleModelValidationRule` / `SingleModelValidationContext`.
- Reframes the docs: `docs/changelog/v5.md` becomes the **upcoming v5.0.0 removal guide** (the rename itself shipped non-breaking in 4.1.0); testing.md warning + changelog index adjusted accordingly.

## After merging this

release-please will regenerate #32 as **4.1.0**. It may still list the `feat!` under a "⚠ BREAKING CHANGES" heading (that comes from the `!` in the already-merged commit subject, which we can't change) — **remove that section from #32's body before merging it**. Then merging #32 tags **v4.1.0**.

## Verification

`:bpmn-to-code-core:compileKotlin` green; `vitepress build` green (no dead links). No behavior change.
