### PR TITLE
docs(testing): mark cross-process rules available since 4.1.0 [Release-As: 4.1.0]

### DIFF
--- a/docs/validate/testing.md
+++ b/docs/validate/testing.md
@@ -263,6 +263,8 @@ The same mappings are surfaced in the [generated Process API](/guide/generated-a
 
 ## Cross-Process (Multi-Model) Rules
 
+_Available since 4.1.0._
+
 A [`SingleModelValidationRule`](#writing-custom-rules) sees one process at a time — it can never reason
 about the relationship *between* two processes. For checks that span files — for example whether a call
 activity's called process actually exists among your models — implement `CrossModelValidationRule`


### PR DESCRIPTION
Pins the pending release to **4.1.0** (the rename is source-compatible via `@Deprecated` typealiases → minor, not major).

The previous attempt (#33) lost the `Release-As` trailer because the squash dropped the commit body. This time the trailer will be forced into the squash commit message at merge.

Also adds a small "available since 4.1.0" note to the cross-process docs (gives the PR a real diff so CI runs).