### PR TITLE
refactor(validation): document purpose of each validation rule

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/CollisionDetectionRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/CollisionDetectionRule.kt
@@ -7,6 +7,10 @@ import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationPhase
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
+/**
+ * Flags when distinct BPMN elements collapse to the same generated constant name, causing ID clashes.
+ * Runs post-merge, so it also catches collisions introduced by combining models.
+ */
 class CollisionDetectionRule(
     private val collisionDetectionService: CollisionDetectionService = CollisionDetectionService(),
 ) : SingleModelValidationRule {

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/EmptyProcessRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/EmptyProcessRule.kt
@@ -5,6 +5,9 @@ import io.miragon.bpmn.domain.validation.model.Severity
 import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
+/**
+ * Warns when a process contains no flow nodes, so no meaningful API can be generated from it.
+ */
 class EmptyProcessRule : SingleModelValidationRule {
 
     override val id = "empty-process"

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingCalledElementRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingCalledElementRule.kt
@@ -5,6 +5,9 @@ import io.miragon.bpmn.domain.validation.model.Severity
 import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
+/**
+ * Flags call activities that reference no target process (missing 'calledElement' / 'processId').
+ */
 class MissingCalledElementRule : SingleModelValidationRule {
 
     override val id = "missing-called-element"

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingErrorDefinitionRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingErrorDefinitionRule.kt
@@ -5,6 +5,9 @@ import io.miragon.bpmn.domain.validation.model.Severity
 import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
+/**
+ * Flags error events whose definition lacks a 'name' or 'errorCode' attribute.
+ */
 class MissingErrorDefinitionRule : SingleModelValidationRule {
 
     override val id = "missing-error-definition"

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingMessageNameRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingMessageNameRule.kt
@@ -5,6 +5,9 @@ import io.miragon.bpmn.domain.validation.model.Severity
 import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
+/**
+ * Flags message elements that are missing a 'name' attribute.
+ */
 class MissingMessageNameRule : SingleModelValidationRule {
 
     override val id = "missing-message-name"

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingProcessIdRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingProcessIdRule.kt
@@ -5,6 +5,9 @@ import io.miragon.bpmn.domain.validation.model.Severity
 import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
+/**
+ * Flags a model with a blank process ID, which is required to identify the generated API.
+ */
 class MissingProcessIdRule : SingleModelValidationRule {
 
     override val id = "missing-process-id"

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingServiceTaskImplementationRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingServiceTaskImplementationRule.kt
@@ -6,6 +6,9 @@ import io.miragon.bpmn.domain.validation.model.Severity
 import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
+/**
+ * Flags service tasks with no implementation, with an engine-specific hint on what to configure.
+ */
 class MissingServiceTaskImplementationRule : SingleModelValidationRule {
 
     override val id = "missing-service-task-implementation"

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingSignalNameRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingSignalNameRule.kt
@@ -5,6 +5,9 @@ import io.miragon.bpmn.domain.validation.model.Severity
 import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
+/**
+ * Flags signal events whose definition is missing a 'name' attribute.
+ */
 class MissingSignalNameRule : SingleModelValidationRule {
 
     override val id = "missing-signal-name"

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingTimerDefinitionRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingTimerDefinitionRule.kt
@@ -5,6 +5,9 @@ import io.miragon.bpmn.domain.validation.model.Severity
 import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
 import io.miragon.bpmn.domain.validation.model.ValidationViolation
 
+/**
+ * Flags timer events that have no resolvable type (Date, Duration, or Cycle).
+ */
 class MissingTimerDefinitionRule : SingleModelValidationRule {
 
     override val id = "missing-timer-definition"


### PR DESCRIPTION
Adds a compact KDoc comment stating the purpose of each rule in `domain/validation/rules/` that lacked one, matching the style of the rules that already had comments.

No behavior change — comments only.