### PR TITLE
test(architecture): expand Konsist architecture guardrails

### DIFF
--- a/bpmn-to-code-architecture-tests/src/test/kotlin/io/miragon/bpmn/architecture/CodingGuidelinesTest.kt
+++ b/bpmn-to-code-architecture-tests/src/test/kotlin/io/miragon/bpmn/architecture/CodingGuidelinesTest.kt
@@ -1,0 +1,23 @@
+package io.miragon.bpmn.architecture
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * General Kotlin coding guidelines that apply project-wide, independent of the hexagonal layering
+ * (which lives in [HexagonalArchitectureTest]). These are source-structure rules Konsist can see but
+ * the compiler erases — the reason Konsist earns its place here.
+ */
+class CodingGuidelinesTest {
+
+    @Test
+    fun `each source file declares at most one top-level type`() {
+        Konsist
+            .scopeFromProject()
+            .files
+            .assertTrue(testName = "files should declare at most one top-level type to follow SRP") { file ->
+                file.classesAndInterfacesAndObjects(includeNested = false, includeLocal = false).size <= 1
+            }
+    }
+}

--- a/bpmn-to-code-architecture-tests/src/test/kotlin/io/miragon/bpmn/architecture/HexagonalArchitectureTest.kt
+++ b/bpmn-to-code-architecture-tests/src/test/kotlin/io/miragon/bpmn/architecture/HexagonalArchitectureTest.kt
@@ -8,36 +8,70 @@ import com.lemonappdev.konsist.api.verify.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+/**
+ * Enforces the hexagonal (ports & adapters) structure of `bpmn-to-code-core`: layer dependencies,
+ * technology-neutrality of the domain, port/adapter typing and package placement.
+ *
+ * Naming conventions live in [NamingConventionArchitectureTest], general Kotlin coding guidelines in
+ * [CodingGuidelinesTest], and cross-module import boundaries in [ExternalModuleImportTest]. Everything
+ * runs on Konsist, which reads the project's Kotlin source straight off disk — so this module depends
+ * on no other module (see the build file).
+ */
 class HexagonalArchitectureTest {
 
     private val rootPackage = "io.miragon.bpmn"
 
-    @Test
-    fun `hexagonal architecture layers are respected`() {
-        Konsist
-            .scopeFromProject()
-            .assertArchitecture {
-                val domainLayer = Layer("Domain", "$rootPackage.domain..")
-                val inPortsLayer = Layer("In-Ports", "$rootPackage.application.port.inbound..")
-                val outPortsLayer = Layer("Out-Ports", "$rootPackage.application.port.outbound..")
-                val inAdaptersLayer = Layer("In-Adapters", "$rootPackage.adapter.inbound..")
-                val outAdaptersLayer = Layer("Out-Adapters", "$rootPackage.adapter.outbound..")
-                val applicationLayer = Layer("Application", "$rootPackage.application.service..")
+    @Nested
+    inner class Dependencies {
 
-                domainLayer.dependsOnNothing()
-                inPortsLayer.dependsOn(domainLayer)
-                outPortsLayer.dependsOn(domainLayer)
-                outAdaptersLayer.dependsOn(domainLayer, outPortsLayer)
-                // Services import concrete out-adapter classes as constructor default values (no DI framework).
-                // The constructor parameter TYPES must still be out-port interfaces — enforced separately below.
-                applicationLayer.dependsOn(domainLayer, inPortsLayer, outPortsLayer, outAdaptersLayer)
-                // In-adapters act as composition root: they instantiate services (which wire their own adapters).
-                inAdaptersLayer.dependsOn(domainLayer, inPortsLayer, applicationLayer)
-            }
+        @Test
+        fun `hexagonal architecture layers are respected`() {
+            Konsist
+                .scopeFromProject()
+                .assertArchitecture {
+                    val domainLayer = Layer("Domain", "$rootPackage.domain..")
+                    val inPortsLayer = Layer("In-Ports", "$rootPackage.application.port.inbound..")
+                    val outPortsLayer = Layer("Out-Ports", "$rootPackage.application.port.outbound..")
+                    val inAdaptersLayer = Layer("In-Adapters", "$rootPackage.adapter.inbound..")
+                    val outAdaptersLayer = Layer("Out-Adapters", "$rootPackage.adapter.outbound..")
+                    val applicationLayer = Layer("Application", "$rootPackage.application.service..")
+
+                    domainLayer.dependsOnNothing()
+                    inPortsLayer.dependsOn(domainLayer)
+                    outPortsLayer.dependsOn(domainLayer)
+                    outAdaptersLayer.dependsOn(domainLayer, outPortsLayer)
+                    applicationLayer.dependsOn(domainLayer, inPortsLayer, outPortsLayer, outAdaptersLayer)
+                    inAdaptersLayer.dependsOn(domainLayer, inPortsLayer, applicationLayer)
+                }
+        }
+
+        @Test
+        fun `domain only depends on language, logging and its own code`() {
+            Konsist
+                .scopeFromPackage("$rootPackage.domain..")
+                .files
+                .filter { it.path.contains("/src/main/") }
+                .assertTrue(testName = "domain files should only import language, logging or domain code") { file ->
+                    file.imports.all { import ->
+                        DOMAIN_ALLOWED_IMPORT_PREFIXES.any { import.name.startsWith(it) }
+                    }
+                }
+        }
+
+        @Test
+        fun `services do not depend on other application services`() {
+            Konsist
+                .scopeFromPackage("$rootPackage.application.service..")
+                .files
+                .filter { it.path.contains("/src/main/") }
+                .assertTrue { file ->
+                    file.imports.none { it.name.startsWith("$rootPackage.application.service.") }
+                }
+        }
     }
 
     @Nested
-    inner class PortTests {
+    inner class Ports {
 
         @Test
         fun `all ports are interfaces`() {
@@ -49,16 +83,7 @@ class HexagonalArchitectureTest {
     }
 
     @Nested
-    inner class ServiceTests {
-
-        @Test
-        fun `services are named with Service suffix`() {
-            Konsist
-                .scopeFromPackage("$rootPackage.application.service..")
-                .classesAndInterfacesAndObjects(includeNested = false, includeLocal = false)
-                .filter { it.path.contains("/src/main/") }
-                .assertTrue { it.hasNameEndingWith("Service") }
-        }
+    inner class Services {
 
         @Test
         fun `each service imports exactly one inbound port`() {
@@ -94,21 +119,38 @@ class HexagonalArchitectureTest {
     }
 
     @Nested
-    inner class FileStructureTests {
+    inner class Structure {
+
+        // Scoped to core: the inbound/outbound hexagon layout is a `bpmn-to-code-core` convention. The
+        // plugin modules keep their own adapter classes directly under `adapter` (e.g. Gradle tasks).
 
         @Test
-        fun `each source file declares at most one top-level type`() {
+        fun `application classes reside in service or port sub-packages`() {
             Konsist
-                .scopeFromProject()
-                .files
-                .assertTrue(testName = "files should declare at most one top-level type to follow SRP") { file ->
-                    file.classesAndInterfacesAndObjects(includeNested = false, includeLocal = false).size <= 1
+                .scopeFromPackage("$rootPackage.application..")
+                .classesAndInterfacesAndObjects(includeNested = false, includeLocal = false)
+                .filter { it.path.contains(CORE_MAIN_PATH) }
+                .assertTrue { declaration ->
+                    declaration.resideInPackage("$rootPackage.application.service..") ||
+                        declaration.resideInPackage("$rootPackage.application.port..")
+                }
+        }
+
+        @Test
+        fun `adapter classes reside in inbound or outbound sub-packages`() {
+            Konsist
+                .scopeFromPackage("$rootPackage.adapter..")
+                .classesAndInterfacesAndObjects(includeNested = false, includeLocal = false)
+                .filter { it.path.contains(CORE_MAIN_PATH) }
+                .assertTrue { declaration ->
+                    declaration.resideInPackage("$rootPackage.adapter.inbound..") ||
+                        declaration.resideInPackage("$rootPackage.adapter.outbound..")
                 }
         }
     }
 
     @Nested
-    inner class InAdapterTests {
+    inner class InAdapters {
 
         @Test
         fun `in-adapter constructor parameters are typed as inbound port interfaces, not concrete service implementations`() {
@@ -128,5 +170,37 @@ class HexagonalArchitectureTest {
                     serviceImportNames.none { it in constructorParamTypeNames }
                 }
         }
+
+        @Test
+        fun `each in-adapter fulfils at most one use-case`() {
+            Konsist
+                .scopeFromPackage("$rootPackage.adapter.inbound..")
+                .files
+                .filter { it.path.contains("/src/main/") }
+                .assertTrue { file ->
+                    val inboundPortImports = file.imports
+                        .filter { it.name.contains(".application.port.inbound.") }
+                    inboundPortImports.size <= 1
+                }
+        }
+    }
+
+    private companion object {
+
+        /** Restricts a whole-project scan to `bpmn-to-code-core`'s production sources. */
+        const val CORE_MAIN_PATH = "/bpmn-to-code-core/src/main/"
+
+        /**
+         * Package prefixes the technology-neutral domain may import from: the Kotlin & Java languages,
+         * the kotlin-logging facade ([io.github.oshai]) used by domain services, and the domain itself.
+         */
+        val DOMAIN_ALLOWED_IMPORT_PREFIXES = listOf(
+            "kotlin.",
+            "kotlinx.",
+            "java.",
+            "javax.",
+            "io.github.oshai.",
+            "io.miragon.bpmn.domain.",
+        )
     }
 }

--- a/bpmn-to-code-architecture-tests/src/test/kotlin/io/miragon/bpmn/architecture/NamingConventionArchitectureTest.kt
+++ b/bpmn-to-code-architecture-tests/src/test/kotlin/io/miragon/bpmn/architecture/NamingConventionArchitectureTest.kt
@@ -1,0 +1,97 @@
+package io.miragon.bpmn.architecture
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Naming conventions per hexagonal layer, read straight from the Kotlin source with Konsist.
+ *
+ * Each rule lists the class-name suffixes allowed in a package together with a short rationale via
+ * [AllowedSuffix], so the file doubles as living documentation of what each layer's types are called.
+ *
+ * Outbound-adapter naming is intentionally *not* constrained: `adapter.outbound` legitimately holds a
+ * heterogeneous mix (adapters, mappers, loaders, generators, extractors, JSON models, utils, constants,
+ * enums), so a suffix whitelist there would be noisy and high-maintenance rather than a useful guardrail.
+ */
+class NamingConventionArchitectureTest {
+
+    private val rootPackage = "io.miragon.bpmn"
+
+    @Nested
+    inner class Ports {
+
+        @Test
+        fun `inbound ports are use-cases or queries`() {
+            checkNaming(
+                packagePattern = "$rootPackage.application.port.inbound..",
+                allowedSuffixes = listOf(
+                    AllowedSuffix("UseCase", "inbound port for a state-changing operation"),
+                    AllowedSuffix("Query", "inbound port for a read-only operation"),
+                ),
+            )
+        }
+
+        @Test
+        fun `outbound ports are ports or repositories`() {
+            checkNaming(
+                packagePattern = "$rootPackage.application.port.outbound..",
+                allowedSuffixes = listOf(
+                    AllowedSuffix("Port", "generic outbound port delegating to an out-adapter"),
+                    AllowedSuffix("Repository", "outbound port for persistence access"),
+                ),
+            )
+        }
+    }
+
+    @Nested
+    inner class Application {
+
+        @Test
+        fun `application services are named with a Service suffix`() {
+            checkNaming(
+                packagePattern = "$rootPackage.application.service..",
+                allowedSuffixes = listOf(
+                    AllowedSuffix("Service", "orchestrates a single use case"),
+                ),
+            )
+        }
+    }
+
+    @Nested
+    inner class InboundAdapters {
+
+        @Test
+        fun `inbound adapters are plugins`() {
+            checkNaming(
+                packagePattern = "$rootPackage.adapter.inbound..",
+                allowedSuffixes = listOf(
+                    AllowedSuffix("Plugin", "driving entry point wiring a use case to its adapters"),
+                ),
+            )
+        }
+    }
+
+    private fun checkNaming(
+        packagePattern: String,
+        allowedSuffixes: List<AllowedSuffix>,
+    ) {
+        Konsist
+            .scopeFromPackage(packagePattern)
+            .classesAndInterfacesAndObjects(includeNested = false, includeLocal = false)
+            .filter { it.path.contains("/src/main/") }
+            .assertTrue { declaration ->
+                allowedSuffixes.any { declaration.hasNameEndingWith(it.suffix) }
+            }
+    }
+
+    /**
+     * An allowed class-name suffix together with a short rationale. The [reason] documents *why* the
+     * suffix is allowed and doubles as inline documentation; it is not part of Konsist's failure message.
+     */
+    private data class AllowedSuffix(
+        val suffix: String,
+        val reason: String,
+    )
+}


### PR DESCRIPTION
## Why

Reviewed the combined **ArchUnit + Konsist** architecture-test examples in
[`emaarco/spring-gardium-leviosa`](https://github.com/emaarco/spring-gardium-leviosa/tree/main/examples)
and evaluated whether ArchUnit or Konsist fits `bpmn-to-code`.

**Conclusion — stay Konsist-only, adopt the good ideas, not the tool.** Two of our
constraints invert the external repo's ArchUnit/Konsist trade-off:

- **Multi-module library:** Konsist reads source from disk (`scopeFromProject()`), so the
  guardrail module depends on no other module. ArchUnit would need every module's *bytecode*
  on the test classpath — coupling the very module meant to enforce decoupling.
- **No DI framework:** services wire concrete adapters as constructor *defaults* while param
  *types* stay interfaces. That source-level distinction is only visible to Konsist; ArchUnit
  (bytecode) would flag legitimate code. The only real thing we give up is cycle detection.

## What changed

All rules stay in Konsist. New/expanded guardrails in `bpmn-to-code-architecture-tests`:

- **`NamingConventionArchitectureTest`** *(new)* — per-layer name suffixes with documented
  rationale (`AllowedSuffix`): inbound ports → `UseCase`/`Query`, outbound ports →
  `Port`/`Repository`, services → `Service`, inbound adapters → `Plugin`. Outbound-adapter
  naming intentionally left unconstrained (too heterogeneous).
- **`HexagonalArchitectureTest`** — added domain technology-neutrality, package placement
  (core-scoped), no service→service dependency, in-adapter ≤ 1 use-case; reorganised into
  named `@Nested` groups.
- **`CodingGuidelinesTest`** *(new)* — one top-level type per file, extracted from the
  hexagonal suite as a general Kotlin guideline.

Deliberately **not** duplicated: wildcard-import / style rules (already covered by detekt) and
abstract parameterised base classes (only useful for a shared rules library).

## Verification

- `./gradlew :bpmn-to-code-architecture-tests:test` → green (all rules describe the current state)
- RED counter-check: a mis-named inbound port makes the naming rule fail, green again after removal
- `./gradlew :bpmn-to-code-architecture-tests:detekt` → green