### PR TITLE
feat(engine): detect Camunda 8 connector service tasks (#42)

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/constants/ZeebeModelConstants.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/constants/ZeebeModelConstants.kt
@@ -6,6 +6,8 @@ package io.miragon.bpmn.adapter.outbound.engine.constants
  */
 object ZeebeModelConstants {
 
+    const val NAMESPACE = "http://camunda.org/schema/zeebe/1.0"
+
     const val ELEMENT_TASK_DEFINITION = "taskDefinition"
     const val ELEMENT_IO_MAPPING = "ioMapping"
     const val ELEMENT_INPUT = "input"
@@ -23,4 +25,5 @@ object ZeebeModelConstants {
     const val ATTRIBUTE_INPUT_COLLECTION = "inputCollection"
     const val ATTRIBUTE_OUTPUT_ELEMENT = "outputElement"
     const val ATTRIBUTE_OUTPUT_COLLECTION = "outputCollection"
+    const val ATTRIBUTE_MODELER_TEMPLATE = "modelerTemplate"
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeImplementationKind.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeImplementationKind.kt
@@ -1,5 +1,6 @@
 package io.miragon.bpmn.adapter.outbound.engine.extractor
 
 enum class ZeebeImplementationKind {
-    JOB_WORKER
+    JOB_WORKER,
+    CONNECTOR,
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
@@ -7,6 +7,8 @@ import io.miragon.bpmn.adapter.outbound.engine.utils.BaseElementUtils.findExtens
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.extractAttribute
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.filterByType
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.findFirstByType
+import io.miragon.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.nonBlankAttribute
+import io.miragon.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.nonBlankAttributeNs
 import io.miragon.bpmn.adapter.outbound.engine.utils.MessageUtils.findAllMessagesWithSource
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findCompensateEventDefinitions
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findErrorEventDefinition
@@ -156,20 +158,16 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
             val taskDefinition = extensionElements.findFirstByType(ZeebeModelConstants.ELEMENT_TASK_DEFINITION)
                 ?: return@mapNotNull null
             val id = node.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
-            val type = taskDefinition.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_TYPE)
-                ?.takeIf { it.isNotBlank() }
-            val modelerTemplate = node
-                .getAttributeValueNs(ZeebeModelConstants.NAMESPACE, ZeebeModelConstants.ATTRIBUTE_MODELER_TEMPLATE)
-                ?.takeIf { it.isNotBlank() }
-            val kind = when {
-                modelerTemplate != null -> ZeebeImplementationKind.CONNECTOR
-                else -> ZeebeImplementationKind.JOB_WORKER
-            }
+            val type = taskDefinition.nonBlankAttribute(BpmnModelConstants.BPMN_ATTRIBUTE_TYPE)
+            val modelerTemplate = node.nonBlankAttributeNs(ZeebeModelConstants.NAMESPACE, ZeebeModelConstants.ATTRIBUTE_MODELER_TEMPLATE)
             ServiceTaskDefinition(
                 id = id,
                 engineSpecificProperties = buildMap {
                     put(implValueKey, type)
-                    put(implKindKey, kind.name)
+                    put(implKindKey, when {
+                        modelerTemplate != null -> ZeebeImplementationKind.CONNECTOR.name
+                        else -> ZeebeImplementationKind.JOB_WORKER.name
+                    })
                 }
             )
         }

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
@@ -158,11 +158,18 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
             val id = node.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
             val type = taskDefinition.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_TYPE)
                 ?.takeIf { it.isNotBlank() }
+            val modelerTemplate = node
+                .getAttributeValueNs(ZeebeModelConstants.NAMESPACE, ZeebeModelConstants.ATTRIBUTE_MODELER_TEMPLATE)
+                ?.takeIf { it.isNotBlank() }
+            val kind = when {
+                modelerTemplate != null -> ZeebeImplementationKind.CONNECTOR
+                else -> ZeebeImplementationKind.JOB_WORKER
+            }
             ServiceTaskDefinition(
                 id = id,
                 engineSpecificProperties = buildMap {
                     put(implValueKey, type)
-                    put(implKindKey, ZeebeImplementationKind.JOB_WORKER.name)
+                    put(implKindKey, kind.name)
                 }
             )
         }

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/utils/ModelElementInstanceUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/utils/ModelElementInstanceUtils.kt
@@ -16,4 +16,12 @@ object ModelElementInstanceUtils {
         return mapNotNull { it.domElement.getAttribute(attributeName) }
     }
 
+    fun ModelElementInstance.nonBlankAttribute(name: String): String? {
+        return getAttributeValue(name)?.takeIf { it.isNotBlank() }
+    }
+
+    fun ModelElementInstance.nonBlankAttributeNs(namespace: String, name: String): String? {
+        return getAttributeValueNs(namespace, name)?.takeIf { it.isNotBlank() }
+    }
+
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -215,7 +215,23 @@ class ZeebeModelExtractorTest {
             VariableDefinition("subscriber", VariableDirection.INPUT, "subscriber"),
             VariableDefinition("results", VariableDirection.OUTPUT, "results"),
             VariableDefinition("result", VariableDirection.OUTPUT, "=result"),
+            VariableDefinition("method", VariableDirection.INPUT, "POST"),
+            VariableDefinition("url", VariableDirection.INPUT, "https://api.example.com/newsletter"),
+            VariableDefinition("apiResponse", VariableDirection.OUTPUT, "=response"),
         )
+    }
+
+    @Test
+    fun `extract classifies element-template service tasks as connectors`() {
+        val file = File(requireNotNull(javaClass.getResource("/bpmn/c8-send-newsletter.bpmn")).toURI())
+        val bpmnModel = underTest.extract(file.readBytes())
+
+        val kindByType = bpmnModel.serviceTasks.associate {
+            it.engineSpecificProperties[IMPL_VALUE_KEY] to it.engineSpecificProperties[IMPL_KIND_KEY]
+        }
+        assertThat(kindByType["io.camunda:http-json:1"]).isEqualTo("CONNECTOR")
+        assertThat(kindByType["newsletter.loadSubscribers"]).isEqualTo("JOB_WORKER")
+        assertThat(kindByType["newsletter.notifyAuthors"]).isEqualTo("JOB_WORKER")
     }
 
     @Test

--- a/shared/bpmn/c8-send-newsletter.bpmn
+++ b/shared/bpmn/c8-send-newsletter.bpmn
@@ -42,7 +42,7 @@
       </bpmn:multiInstanceLoopCharacteristics>
     </bpmn:serviceTask>
     <bpmn:endEvent id="endEvent_editionSent" name="Newsletter edition send">
-      <bpmn:incoming>Flow_0v2v55n</bpmn:incoming>
+      <bpmn:incoming>Flow_1conn0</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1ruayvl" sourceRef="serviceTask_sendToSubscriber" targetRef="serviceTask_notifyAuthor" />
     <bpmn:serviceTask id="serviceTask_notifyAuthor" name="Notify authors">
@@ -60,7 +60,20 @@
         </bpmn:extensionElements>
       </bpmn:multiInstanceLoopCharacteristics>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0v2v55n" sourceRef="serviceTask_notifyAuthor" targetRef="endEvent_editionSent" />
+    <bpmn:sequenceFlow id="Flow_0v2v55n" sourceRef="serviceTask_notifyAuthor" targetRef="serviceTask_publishNewsletter" />
+    <bpmn:serviceTask id="serviceTask_publishNewsletter" name="Publish newsletter online" zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda:http-json:1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="POST" target="method" />
+          <zeebe:input source="https://api.example.com/newsletter" target="url" />
+          <zeebe:output source="=response" target="apiResponse" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0v2v55n</bpmn:incoming>
+      <bpmn:outgoing>Flow_1conn0</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1conn0" sourceRef="serviceTask_publishNewsletter" targetRef="endEvent_editionSent" />
     <bpmn:subProcess id="eventSubProcess_errorHandling" name="Error handling" triggeredByEvent="true">
       <bpmn:startEvent id="event_mailRejected" name="Mail rejected">
         <bpmn:outgoing>Flow_0vtppnk</bpmn:outgoing>
@@ -164,14 +177,17 @@
         <dc:Bounds x="510" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1nlgapd_di" bpmnElement="endEvent_editionSent">
-        <dc:Bounds x="812" y="102" width="36" height="36" />
+        <dc:Bounds x="982" y="102" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="677" y="145" width="88" height="27" />
+          <dc:Bounds x="847" y="145" width="88" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0o94zo3_di" bpmnElement="serviceTask_notifyAuthor">
         <dc:Bounds x="650" y="80" width="100" height="80" />
         <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_publishNewsletter_di" bpmnElement="serviceTask_publishNewsletter">
+        <dc:Bounds x="810" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1f48jdy_di" bpmnElement="eventSubProcess_errorHandling" isExpanded="true">
         <dc:Bounds x="165" y="350" width="910" height="290" />
@@ -301,7 +317,11 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0v2v55n_di" bpmnElement="Flow_0v2v55n">
         <di:waypoint x="750" y="120" />
-        <di:waypoint x="812" y="120" />
+        <di:waypoint x="810" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1conn0_di" bpmnElement="Flow_1conn0">
+        <di:waypoint x="910" y="120" />
+        <di:waypoint x="982" y="120" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/shared/bpmn/c8-send-newsletter.bpmn
+++ b/shared/bpmn/c8-send-newsletter.bpmn
@@ -176,18 +176,18 @@
       <bpmndi:BPMNShape id="Activity_0mmvsvx_di" bpmnElement="serviceTask_sendToSubscriber">
         <dc:Bounds x="510" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1nlgapd_di" bpmnElement="endEvent_editionSent">
-        <dc:Bounds x="982" y="102" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="847" y="145" width="88" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0o94zo3_di" bpmnElement="serviceTask_notifyAuthor">
         <dc:Bounds x="650" y="80" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_publishNewsletter_di" bpmnElement="serviceTask_publishNewsletter">
-        <dc:Bounds x="810" y="80" width="100" height="80" />
+        <dc:Bounds x="790" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1nlgapd_di" bpmnElement="endEvent_editionSent">
+        <dc:Bounds x="932" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="906" y="156" width="88" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1f48jdy_di" bpmnElement="eventSubProcess_errorHandling" isExpanded="true">
         <dc:Bounds x="165" y="350" width="910" height="290" />
@@ -317,11 +317,11 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0v2v55n_di" bpmnElement="Flow_0v2v55n">
         <di:waypoint x="750" y="120" />
-        <di:waypoint x="810" y="120" />
+        <di:waypoint x="790" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1conn0_di" bpmnElement="Flow_1conn0">
-        <di:waypoint x="910" y="120" />
-        <di:waypoint x="982" y="120" />
+        <di:waypoint x="890" y="120" />
+        <di:waypoint x="932" y="120" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
## What

Refs #42. Camunda 8 REST outbound connectors are service tasks backed by a `zeebe:modelerTemplate` element template (with a `zeebe:taskDefinition type="io.camunda:http-json:1"`). Until now every Zeebe service task was classified as a plain job worker — `ZeebeImplementationKind` had only `JOB_WORKER`, hardcoded in `findServiceTasks()` — so connectors were mislabeled.

## Change

- `ZeebeImplementationKind` gains a `CONNECTOR` value.
- `ZeebeModelExtractor.findServiceTasks()` reads the `zeebe:modelerTemplate` attribute (via the existing `getAttributeValueNs` pattern) and classifies a task as `CONNECTOR` when a template is present, else `JOB_WORKER`.
- New constants: `ZeebeModelConstants.NAMESPACE` and `ATTRIBUTE_MODELER_TEMPLATE`.

Scope is deliberately minimal (as agreed on the issue): **internal detection only**. The **generated Kotlin/Java API is byte-identical** — no golden file changes. Connector element ids already surface under `Elements`, and their `zeebe:ioMapping` inputs/outputs already surface under `Variables`. The one observable effect is that the classification flows through `BpmnJsonMapper` into the JSON model's `implementationKind`, which now correctly reports `CONNECTOR` instead of `JOB_WORKER`.

## Tests

- Added a realistic HTTP-JSON connector task (`Publish newsletter online`) to the existing `shared/bpmn/c8-send-newsletter.bpmn` — the lowest-churn host (read only by `ZeebeModelExtractorTest`, backs no golden).
- `ZeebeModelExtractorTest`: extended the `variables` assertion with the connector's io vars (demonstrating in/outputs flow through the existing `Variables` path) and added a focused test asserting the connector → `CONNECTOR` while workers stay `JOB_WORKER`.

## Follow-up

A future ticket can decide whether/how to surface connectors distinctly in the generated API (dedicated `Connectors` section, endpoint constants, etc.). This lands the detection foundation, non-breaking.

## Verification

- `./gradlew :bpmn-to-code-core:test :bpmn-to-code-core:jacocoTestCoverageVerification` ✅
- `./gradlew :bpmn-to-code-{web,testing,runtime}:jacocoTestCoverageVerification :bpmn-to-code-gradle:test :bpmn-to-code-maven:test` ✅
- `./gradlew :bpmn-to-code-core:detekt` ✅
- Confirmed no golden `api/*.txt` or `*.json` fixture changed.