### PR TITLE
feat(testing): add opt-in uncaught-message-throw cross-model rule

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
@@ -7,6 +7,7 @@ import io.miragon.bpmn.adapter.outbound.engine.utils.DomElementUtils.withElement
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.extractAttribute
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.filterByType
 import io.miragon.bpmn.adapter.outbound.engine.utils.MessageUtils.findAllMessagesWithSource
+import io.miragon.bpmn.adapter.outbound.engine.utils.MessageUtils.findMessageEventProperties
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findCompensateEventDefinitions
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findErrorEventDefinition
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findEscalationEventDefinitions
@@ -66,8 +67,9 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
         val variablesPerNode = extractVariablesPerNode(modelInstance)
 
         val asyncPerNode = extractAsyncPerNode(modelInstance)
+        val messageEvents = modelInstance.findMessageEventProperties()
         val allServiceTasks = serviceTasks + messageSendEvents
-        val enrichedFlowNodes = enrichFlowNodes(allFlowNodes, allServiceTasks, callActivities, timers, variablesPerNode, asyncPerNode)
+        val enrichedFlowNodes = enrichFlowNodes(allFlowNodes, allServiceTasks, callActivities, timers, messageEvents, variablesPerNode, asyncPerNode)
 
         return BpmnModel(
             processId = processId,
@@ -89,6 +91,7 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
         serviceTasks: List<ServiceTaskDefinition>,
         callActivities: List<CallActivityDefinition>,
         timers: List<TimerDefinition>,
+        messageEvents: Map<String, FlowNodeProperties.MessageEvent>,
         variablesPerNode: Map<String?, List<VariableDefinition>>,
         asyncPerNode: Map<String?, Map<String, Any?>>,
     ): List<FlowNodeDefinition> {
@@ -100,7 +103,7 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
             .groupBy { it.attachedToRef!! }
             .mapValues { (_, nodes) -> nodes.mapNotNull { it.id } }
         return flowNodes.map { node ->
-            val properties = resolveProperties(node.id, serviceTaskById, callActivityById, timerById)
+            val properties = resolveProperties(node.id, serviceTaskById, callActivityById, timerById, messageEvents)
             val variables = variablesPerNode[node.id] ?: emptyList()
             val attachedElements = attachedElementsById[node.id] ?: emptyList()
             val engineSpecificProperties = asyncPerNode[node.id] ?: emptyMap()
@@ -130,11 +133,12 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
         serviceTasks: Map<String?, ServiceTaskDefinition>,
         callActivities: Map<String?, CallActivityDefinition>,
         timers: Map<String?, TimerDefinition>,
+        messageEvents: Map<String, FlowNodeProperties.MessageEvent>,
     ): FlowNodeProperties {
         serviceTasks[nodeId]?.let { return FlowNodeProperties.ServiceTask(it) }
         callActivities[nodeId]?.let { return FlowNodeProperties.CallActivity(it) }
         timers[nodeId]?.let { return FlowNodeProperties.Timer(it) }
-        return FlowNodeProperties.None
+        return nodeId?.let { messageEvents[it] } ?: FlowNodeProperties.None
     }
 
     private fun findMessages(modelInstance: ModelInstance): List<MessageDefinition> {

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
@@ -69,7 +69,15 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
         val asyncPerNode = extractAsyncPerNode(modelInstance)
         val messageEvents = modelInstance.findMessageEventProperties()
         val allServiceTasks = serviceTasks + messageSendEvents
-        val enrichedFlowNodes = enrichFlowNodes(allFlowNodes, allServiceTasks, callActivities, timers, messageEvents, variablesPerNode, asyncPerNode)
+        val enrichedFlowNodes = enrichFlowNodes(
+            flowNodes = allFlowNodes,
+            serviceTasks = allServiceTasks,
+            callActivities = callActivities,
+            timers = timers,
+            messageEvents = messageEvents,
+            variablesPerNode = variablesPerNode,
+            asyncPerNode = asyncPerNode,
+        )
 
         return BpmnModel(
             processId = processId,

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
@@ -73,7 +73,15 @@ class OperatonModelExtractor : EngineSpecificExtractor {
         val asyncPerNode = extractAsyncPerNode(modelInstance)
         val messageEvents = modelInstance.findMessageEventProperties()
         val allServiceTasks = serviceTasks + messageSendEvents
-        val enrichedFlowNodes = enrichFlowNodes(flowNodes, allServiceTasks, callActivities, timers, messageEvents, variablesPerNode, asyncPerNode)
+        val enrichedFlowNodes = enrichFlowNodes(
+            flowNodes = flowNodes,
+            serviceTasks = allServiceTasks,
+            callActivities = callActivities,
+            timers = timers,
+            messageEvents = messageEvents,
+            variablesPerNode = variablesPerNode,
+            asyncPerNode = asyncPerNode,
+        )
 
         return BpmnModel(
             processId = processId,

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
@@ -7,6 +7,7 @@ import io.miragon.bpmn.adapter.outbound.engine.utils.DomElementUtils.withElement
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.extractAttribute
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.filterByType
 import io.miragon.bpmn.adapter.outbound.engine.utils.MessageUtils.findAllMessagesWithSource
+import io.miragon.bpmn.adapter.outbound.engine.utils.MessageUtils.findMessageEventProperties
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findCompensateEventDefinitions
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findErrorEventDefinition
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findEscalationEventDefinitions
@@ -70,8 +71,9 @@ class OperatonModelExtractor : EngineSpecificExtractor {
         val variablesPerNode = extractVariablesPerNode(modelInstance)
 
         val asyncPerNode = extractAsyncPerNode(modelInstance)
+        val messageEvents = modelInstance.findMessageEventProperties()
         val allServiceTasks = serviceTasks + messageSendEvents
-        val enrichedFlowNodes = enrichFlowNodes(flowNodes, allServiceTasks, callActivities, timers, variablesPerNode, asyncPerNode)
+        val enrichedFlowNodes = enrichFlowNodes(flowNodes, allServiceTasks, callActivities, timers, messageEvents, variablesPerNode, asyncPerNode)
 
         return BpmnModel(
             processId = processId,
@@ -93,6 +95,7 @@ class OperatonModelExtractor : EngineSpecificExtractor {
         serviceTasks: List<ServiceTaskDefinition>,
         callActivities: List<CallActivityDefinition>,
         timers: List<TimerDefinition>,
+        messageEvents: Map<String, FlowNodeProperties.MessageEvent>,
         variablesPerNode: Map<String?, List<VariableDefinition>>,
         asyncPerNode: Map<String?, Map<String, Any?>>,
     ): List<FlowNodeDefinition> {
@@ -104,7 +107,7 @@ class OperatonModelExtractor : EngineSpecificExtractor {
             .groupBy { it.attachedToRef!! }
             .mapValues { (_, nodes) -> nodes.mapNotNull { it.id } }
         return flowNodes.map { node ->
-            val properties = resolveProperties(node.id, serviceTaskById, callActivityById, timerById)
+            val properties = resolveProperties(node.id, serviceTaskById, callActivityById, timerById, messageEvents)
             val variables = variablesPerNode[node.id] ?: emptyList()
             val attachedElements = attachedElementsById[node.id] ?: emptyList()
             val engineSpecificProperties = asyncPerNode[node.id] ?: emptyMap()
@@ -133,11 +136,12 @@ class OperatonModelExtractor : EngineSpecificExtractor {
         serviceTasks: Map<String?, ServiceTaskDefinition>,
         callActivities: Map<String?, CallActivityDefinition>,
         timers: Map<String?, TimerDefinition>,
+        messageEvents: Map<String, FlowNodeProperties.MessageEvent>,
     ): FlowNodeProperties {
         serviceTasks[nodeId]?.let { return FlowNodeProperties.ServiceTask(it) }
         callActivities[nodeId]?.let { return FlowNodeProperties.CallActivity(it) }
         timers[nodeId]?.let { return FlowNodeProperties.Timer(it) }
-        return FlowNodeProperties.None
+        return nodeId?.let { messageEvents[it] } ?: FlowNodeProperties.None
     }
 
     private fun findMessages(modelInstance: ModelInstance): List<MessageDefinition> {

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
@@ -62,7 +62,14 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
         val variablesPerNode = extractVariablesPerNode(modelInstance)
         val messageEvents = modelInstance.findMessageEventProperties()
 
-        val enrichedFlowNodes = enrichFlowNodes(allFlowNodes, allServiceTasks, allCallActivities, allTimerEvents, messageEvents, variablesPerNode)
+        val enrichedFlowNodes = enrichFlowNodes(
+            flowNodes = allFlowNodes,
+            serviceTasks = allServiceTasks,
+            callActivities = allCallActivities,
+            timers = allTimerEvents,
+            messageEvents = messageEvents,
+            variablesPerNode = variablesPerNode,
+        )
 
         return BpmnModel(
             processId = processId,

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
@@ -10,6 +10,7 @@ import io.miragon.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.f
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.nonBlankAttribute
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.nonBlankAttributeNs
 import io.miragon.bpmn.adapter.outbound.engine.utils.MessageUtils.findAllMessagesWithSource
+import io.miragon.bpmn.adapter.outbound.engine.utils.MessageUtils.findMessageEventProperties
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findCompensateEventDefinitions
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findErrorEventDefinition
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findEscalationEventDefinitions
@@ -59,8 +60,9 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
         val allServiceTasks = findServiceTasks(modelInstance)
         val allCallActivities = findCallActivities(modelInstance)
         val variablesPerNode = extractVariablesPerNode(modelInstance)
+        val messageEvents = modelInstance.findMessageEventProperties()
 
-        val enrichedFlowNodes = enrichFlowNodes(allFlowNodes, allServiceTasks, allCallActivities, allTimerEvents, variablesPerNode)
+        val enrichedFlowNodes = enrichFlowNodes(allFlowNodes, allServiceTasks, allCallActivities, allTimerEvents, messageEvents, variablesPerNode)
 
         return BpmnModel(
             processId = processId,
@@ -82,6 +84,7 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
         serviceTasks: List<ServiceTaskDefinition>,
         callActivities: List<CallActivityDefinition>,
         timers: List<io.miragon.bpmn.domain.shared.TimerDefinition>,
+        messageEvents: Map<String, FlowNodeProperties.MessageEvent>,
         variablesPerNode: Map<String?, List<VariableDefinition>>,
     ): List<FlowNodeDefinition> {
         val serviceTaskById = serviceTasks.associateBy { it.id }
@@ -92,7 +95,7 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
             .groupBy { it.attachedToRef!! }
             .mapValues { (_, nodes) -> nodes.mapNotNull { it.id } }
         return flowNodes.map { node ->
-            val properties = resolveProperties(node.id, serviceTaskById, callActivityById, timerById)
+            val properties = resolveProperties(node.id, serviceTaskById, callActivityById, timerById, messageEvents)
             val variables = variablesPerNode[node.id] ?: emptyList()
             val attachedElements = attachedElementsById[node.id] ?: emptyList()
             node.copy(properties = properties, variables = variables, attachedElements = attachedElements)
@@ -104,11 +107,12 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
         serviceTasks: Map<String?, ServiceTaskDefinition>,
         callActivities: Map<String?, CallActivityDefinition>,
         timers: Map<String?, io.miragon.bpmn.domain.shared.TimerDefinition>,
+        messageEvents: Map<String, FlowNodeProperties.MessageEvent>,
     ): FlowNodeProperties {
         serviceTasks[nodeId]?.let { return FlowNodeProperties.ServiceTask(it) }
         callActivities[nodeId]?.let { return FlowNodeProperties.CallActivity(it) }
         timers[nodeId]?.let { return FlowNodeProperties.Timer(it) }
-        return FlowNodeProperties.None
+        return nodeId?.let { messageEvents[it] } ?: FlowNodeProperties.None
     }
 
     private fun findCallActivities(modelInstance: ModelInstance): List<CallActivityDefinition> {

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/utils/MessageUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/utils/MessageUtils.kt
@@ -1,12 +1,45 @@
 package io.miragon.bpmn.adapter.outbound.engine.utils
 
 import io.miragon.bpmn.adapter.outbound.engine.helpers.MessageSource
+import io.miragon.bpmn.domain.shared.FlowNodeProperties
+import io.miragon.bpmn.domain.shared.MessageDirection
 import org.camunda.bpm.model.bpmn.impl.BpmnModelConstants
 import org.camunda.bpm.model.bpmn.instance.MessageEventDefinition
 import org.camunda.bpm.model.bpmn.instance.ReceiveTask
 import org.camunda.bpm.model.xml.ModelInstance
 
 object MessageUtils {
+
+    /**
+     * Couples each message-bearing node to its message name and throw/catch role, keyed by element id.
+     * Message events derive their role from the carrying event's shape (end / intermediate-throw =
+     * [MessageDirection.THROW]; start / intermediate-catch / boundary = [MessageDirection.CATCH]); a
+     * receive task is always a catcher. Nameless message nodes are skipped — they carry no name to
+     * correlate on and are the concern of the missing-message-name rule.
+     */
+    fun ModelInstance.findMessageEventProperties(): Map<String, FlowNodeProperties.MessageEvent> {
+        val fromEvents = this.getModelElementsByType(MessageEventDefinition::class.java)
+            .mapNotNull { med ->
+                val name = med.message?.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_NAME) ?: return@mapNotNull null
+                val parent = med.parentElement ?: return@mapNotNull null
+                val elementId = parent.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID) ?: return@mapNotNull null
+                val direction = parent.elementType.typeName.toMessageDirection() ?: return@mapNotNull null
+                elementId to FlowNodeProperties.MessageEvent(name, direction)
+            }
+        val fromTasks = this.getModelElementsByType(ReceiveTask::class.java)
+            .mapNotNull { task ->
+                val name = task.message?.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_NAME) ?: return@mapNotNull null
+                val elementId = task.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID) ?: return@mapNotNull null
+                elementId to FlowNodeProperties.MessageEvent(name, MessageDirection.CATCH)
+            }
+        return (fromEvents + fromTasks).toMap()
+    }
+
+    private fun String.toMessageDirection(): MessageDirection? = when (this) {
+        "endEvent", "intermediateThrowEvent" -> MessageDirection.THROW
+        "startEvent", "intermediateCatchEvent", "boundaryEvent" -> MessageDirection.CATCH
+        else -> null
+    }
 
     fun ModelInstance.findEventBasedMessagesWithSource(): List<MessageSource> {
         return this.getModelElementsByType(MessageEventDefinition::class.java)

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/json/BpmnJsonMapper.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/json/BpmnJsonMapper.kt
@@ -110,6 +110,11 @@ class BpmnJsonMapper {
                 timerValue = value.takeIf { it.isNotEmpty() },
             )
         }
+        is FlowNodeProperties.MessageEvent -> FlowNodePropertiesJson(
+            type = "MessageEvent",
+            messageName = name,
+            messageDirection = direction.name,
+        )
     }
 
     private fun SequenceFlowDefinition.toJson(): SequenceFlowJson {

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/json/model/FlowNodePropertiesJson.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/json/model/FlowNodePropertiesJson.kt
@@ -10,4 +10,6 @@ data class FlowNodePropertiesJson(
     val calledElement: String? = null,
     val timerType: String? = null,
     val timerValue: String? = null,
+    val messageName: String? = null,
+    val messageDirection: String? = null,
 )

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/shared/FlowNodeProperties.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/shared/FlowNodeProperties.kt
@@ -5,4 +5,5 @@ sealed interface FlowNodeProperties {
     data class ServiceTask(val definition: ServiceTaskDefinition) : FlowNodeProperties
     data class Timer(val definition: TimerDefinition) : FlowNodeProperties
     data class CallActivity(val definition: CallActivityDefinition) : FlowNodeProperties
+    data class MessageEvent(val name: String, val direction: MessageDirection) : FlowNodeProperties
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/shared/MessageDirection.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/shared/MessageDirection.kt
@@ -1,0 +1,9 @@
+package io.miragon.bpmn.domain.shared
+
+/**
+ * Whether a message-bearing node throws (sends) or catches (receives) its message.
+ */
+enum class MessageDirection {
+    THROW,
+    CATCH,
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/UncaughtMessageThrowRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/UncaughtMessageThrowRule.kt
@@ -1,0 +1,69 @@
+package io.miragon.bpmn.domain.validation.rules
+
+import io.miragon.bpmn.domain.ProcessModel
+import io.miragon.bpmn.domain.shared.FlowNodeDefinition
+import io.miragon.bpmn.domain.shared.FlowNodeProperties
+import io.miragon.bpmn.domain.shared.MessageDirection
+import io.miragon.bpmn.domain.validation.CrossModelValidationRule
+import io.miragon.bpmn.domain.validation.model.CrossModelValidationContext
+import io.miragon.bpmn.domain.validation.model.Severity
+import io.miragon.bpmn.domain.validation.model.ValidationViolation
+
+/**
+ * Flags a message that is thrown (message end / intermediate throw event) but never caught anywhere in
+ * the loaded fileset — silently lost cross-process communication that no single-model rule can detect,
+ * since the catcher may live in another process file.
+ *
+ * Reported as WARN, not ERROR: a legitimate consumer outside the loaded fileset is possible, so the
+ * rule can only warn. Cross-model — only meaningful with the whole related fileset loaded together,
+ * so it is opt-in (see BpmnRules).
+ */
+class UncaughtMessageThrowRule : CrossModelValidationRule {
+
+    override val id = "uncaught-message-throw"
+    override val severity = Severity.WARN
+
+    override fun validate(context: CrossModelValidationContext): List<ValidationViolation> {
+        val thrownMessages = thrownMessages(context)
+        val caughtMessageNames = caughtMessageNames(context)
+
+        return thrownMessages
+            .filterNot { (_, _, message) -> message.name in caughtMessageNames }
+            .map { (model, node, message) ->
+                ValidationViolation(
+                    ruleId = id,
+                    severity = severity,
+                    elementId = node.id,
+                    processId = model.processId,
+                    message = "Message '${message.name}' is thrown by '${node.id}' but has no catching event in the loaded models.",
+                )
+            }
+    }
+
+    private fun thrownMessages(
+        context: CrossModelValidationContext,
+    ): List<Triple<ProcessModel, FlowNodeDefinition, FlowNodeProperties.MessageEvent>> {
+        return context.models.flatMap { model ->
+            model.messageEvents(MessageDirection.THROW).map { (node, message) -> Triple(model, node, message) }
+        }
+    }
+
+    private fun caughtMessageNames(context: CrossModelValidationContext): Set<String> {
+        return context.models
+            .flatMap { model -> model.messageEvents(MessageDirection.CATCH) }
+            .map { (_, message) -> message.name }
+            .toSet()
+    }
+
+    private fun ProcessModel.messageEvents(
+        direction: MessageDirection,
+    ): List<Pair<FlowNodeDefinition, FlowNodeProperties.MessageEvent>> {
+        return flowNodes
+            .mapNotNull { node -> node.messageEvent()?.let { node to it } }
+            .filter { (_, message) -> message.direction == direction }
+    }
+
+    private fun FlowNodeDefinition.messageEvent(): FlowNodeProperties.MessageEvent? {
+        return properties as? FlowNodeProperties.MessageEvent
+    }
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -15,6 +15,7 @@ import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_AFTER_KE
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_BEFORE_KEY
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.EXCLUSIVE_KEY
 import io.miragon.bpmn.domain.shared.FlowNodeProperties
+import io.miragon.bpmn.domain.shared.MessageDirection
 import io.miragon.bpmn.domain.shared.SequenceFlowDefinition
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL_KIND_KEY
@@ -134,6 +135,7 @@ class Camunda7ModelExtractorTest {
                         engineSpecificProperties = mapOf(ASYNC_BEFORE_KEY to true)),
                     FlowNodeDefinition("StartEvent_SubmitRegistrationForm", BpmnNodeType.Event(EventShape.START_EVENT, EventDefinitionType.MESSAGE),
                         displayName = "Submit newsletter form",
+                        properties = FlowNodeProperties.MessageEvent("Message_FormSubmitted", MessageDirection.CATCH),
                         variables = listOf(VariableDefinition("subscriptionId", VariableDirection.OUTPUT, "\${subscriptionId}")),
                         followingElements = listOf("serviceTask_incrementSubscriptionCounter")),
                     FlowNodeDefinition("SubProcess_Confirmation", BpmnNodeType.Activity.SubProcess(SubProcessKind.PLAIN),

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -15,6 +15,7 @@ import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_AFTER_KE
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_BEFORE_KEY
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.EXCLUSIVE_KEY
 import io.miragon.bpmn.domain.shared.FlowNodeProperties
+import io.miragon.bpmn.domain.shared.MessageDirection
 import io.miragon.bpmn.domain.shared.SequenceFlowDefinition
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL_KIND_KEY
@@ -133,6 +134,7 @@ class OperatonModelExtractorTest {
                         engineSpecificProperties = mapOf(ASYNC_BEFORE_KEY to true)),
                     FlowNodeDefinition("StartEvent_SubmitRegistrationForm", BpmnNodeType.Event(EventShape.START_EVENT, EventDefinitionType.MESSAGE),
                         displayName = "Submit newsletter form",
+                        properties = FlowNodeProperties.MessageEvent("Message_FormSubmitted", MessageDirection.CATCH),
                         variables = listOf(VariableDefinition("subscriptionId", VariableDirection.OUTPUT, "\${subscriptionId}")),
                         followingElements = listOf("serviceTask_incrementSubscriptionCounter")),
                     FlowNodeDefinition("SubProcess_Confirmation", BpmnNodeType.Activity.SubProcess(SubProcessKind.PLAIN),

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -13,6 +13,7 @@ import io.miragon.bpmn.domain.shared.EscalationDefinition
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition
 import io.miragon.bpmn.domain.shared.FlowNodeProperties
 import io.miragon.bpmn.domain.shared.MessageDefinition
+import io.miragon.bpmn.domain.shared.MessageDirection
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL_KIND_KEY
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL_VALUE_KEY
@@ -68,6 +69,7 @@ class ZeebeModelExtractorTest {
                         followingElements = listOf("CompensationEndEvent_RegistrationAborted")),
                     FlowNodeDefinition("Activity_ConfirmRegistration", BpmnNodeType.Activity.Task(TaskKind.RECEIVE),
                         displayName = "Confirm subscription",
+                        properties = FlowNodeProperties.MessageEvent("Message_SubscriptionConfirmed", MessageDirection.CATCH),
                         attachedElements = listOf("Timer_EveryDay"),
                         parentId = "SubProcess_Confirmation",
                         previousElements = listOf("Activity_SendConfirmationMail"),
@@ -127,6 +129,7 @@ class ZeebeModelExtractorTest {
                         followingElements = listOf("Activity_SendConfirmationMail")),
                     FlowNodeDefinition("StartEvent_SubmitRegistrationForm", BpmnNodeType.Event(EventShape.START_EVENT, EventDefinitionType.MESSAGE),
                         displayName = "Submit newsletter form",
+                        properties = FlowNodeProperties.MessageEvent("Message_FormSubmitted", MessageDirection.CATCH),
                         variables = listOf(VariableDefinition("subscriptionId", VariableDirection.OUTPUT, "=subscriptionId")),
                         followingElements = listOf("serviceTask_incrementSubscriptionCounter")),
                     FlowNodeDefinition("SubProcess_Confirmation", BpmnNodeType.Activity.SubProcess(SubProcessKind.PLAIN),

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/TestBpmnModel.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/TestBpmnModel.kt
@@ -17,6 +17,7 @@ import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_BEFORE_K
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.EXCLUSIVE_KEY
 import io.miragon.bpmn.domain.shared.FlowNodeProperties
 import io.miragon.bpmn.domain.shared.MessageDefinition
+import io.miragon.bpmn.domain.shared.MessageDirection
 import io.miragon.bpmn.domain.shared.OutputLanguage
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition
@@ -125,6 +126,7 @@ fun testSubscribeNewsletterBpmnModel(
             followingElements = listOf("Activity_SendConfirmationMail")),
         FlowNodeDefinition("StartEvent_SubmitRegistrationForm", BpmnNodeType.Event(EventShape.START_EVENT, EventDefinitionType.MESSAGE),
             displayName = "Submit newsletter form",
+            properties = FlowNodeProperties.MessageEvent("Message_FormSubmitted", MessageDirection.CATCH),
             variables = listOf(VariableDefinition("subscriptionId", VariableDirection.OUTPUT)),
             followingElements = listOf("serviceTask_incrementSubscriptionCounter")),
         FlowNodeDefinition("SubProcess_Confirmation", BpmnNodeType.Activity.SubProcess(SubProcessKind.PLAIN),
@@ -210,6 +212,7 @@ fun testSendNewsletterBpmnModel(
         // Event subprocess: error handling
         FlowNodeDefinition("eventSubProcess_errorHandling", BpmnNodeType.Activity.SubProcess(SubProcessKind.PLAIN)),
         FlowNodeDefinition("event_mailRejected", BpmnNodeType.Event(EventShape.START_EVENT, EventDefinitionType.MESSAGE),
+            properties = FlowNodeProperties.MessageEvent("Message_MailRejected", MessageDirection.CATCH),
             parentId = "eventSubProcess_errorHandling",
             followingElements = listOf("serviceTask_analyzeError")),
         FlowNodeDefinition("serviceTask_analyzeError", BpmnNodeType.Activity.Task(TaskKind.SERVICE),
@@ -234,6 +237,7 @@ fun testSendNewsletterBpmnModel(
             parentId = "eventSubProcess_errorHandling",
             previousElements = listOf("gateway_canSendAgain")),
         FlowNodeDefinition("event_mailRejectedAgain", BpmnNodeType.Event(EventShape.INTERMEDIATE_CATCH_EVENT, EventDefinitionType.MESSAGE),
+            properties = FlowNodeProperties.MessageEvent("Message_MailRejectedAgain", MessageDirection.CATCH),
             parentId = "eventSubProcess_errorHandling",
             previousElements = listOf("eventGateway_afterSendingAgain"), followingElements = listOf("escalationEndEvent_nofitySupportAfterRepeatedError")),
         FlowNodeDefinition("escalationEndEvent_nofitySupportAfterRepeatedError", BpmnNodeType.Event(EventShape.END_EVENT),

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/UncaughtMessageThrowRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/UncaughtMessageThrowRuleTest.kt
@@ -36,7 +36,7 @@ class UncaughtMessageThrowRuleTest {
         // given: a single model that throws a message no one catches
         val thrower = model("orderPlacement", throwNode("throw1", "OrderShipped"))
 
-        // when
+        // when: the rule validates the model
         val violations = validate(thrower)
 
         // then: a single WARN naming the uncaught message and its throwing element
@@ -53,10 +53,10 @@ class UncaughtMessageThrowRuleTest {
         // given: the throw and a matching catch live in one model
         val model = model("orderPlacement", throwNode("throw1", "OrderShipped"), catchNode("catch1", "OrderShipped"))
 
-        // when
+        // when: the rule validates the model
         val violations = validate(model)
 
-        // then
+        // then: no violation is reported
         assertThat(violations).isEmpty()
     }
 
@@ -67,10 +67,10 @@ class UncaughtMessageThrowRuleTest {
         val thrower = model("orderPlacement", throwNode("throw1", "OrderShipped"))
         val catcher = model("shipping", catchNode("catch1", "OrderShipped"))
 
-        // when
+        // when: the rule validates both models together
         val violations = validate(thrower, catcher)
 
-        // then
+        // then: no violation is reported
         assertThat(violations).isEmpty()
     }
 
@@ -81,7 +81,7 @@ class UncaughtMessageThrowRuleTest {
         val thrower = model("orderPlacement", throwNode("throw1", "OrderShipped"), throwNode("throw2", "OrderCancelled"))
         val catcher = model("shipping", catchNode("catch1", "OrderShipped"))
 
-        // when
+        // when: the rule validates both models together
         val violations = validate(thrower, catcher)
 
         // then: only the uncaught message is reported

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/UncaughtMessageThrowRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/UncaughtMessageThrowRuleTest.kt
@@ -1,0 +1,92 @@
+package io.miragon.bpmn.domain.validation.rules
+
+import io.miragon.bpmn.domain.shared.FlowNodeDefinition
+import io.miragon.bpmn.domain.shared.FlowNodeProperties
+import io.miragon.bpmn.domain.shared.MessageDirection
+import io.miragon.bpmn.domain.shared.ProcessEngine
+import io.miragon.bpmn.domain.testBpmnModel
+import io.miragon.bpmn.domain.validation.model.CrossModelValidationContext
+import io.miragon.bpmn.domain.validation.model.Severity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class UncaughtMessageThrowRuleTest {
+
+    private val underTest = UncaughtMessageThrowRule()
+
+    private fun throwNode(id: String, message: String) = FlowNodeDefinition(
+        id = id,
+        properties = FlowNodeProperties.MessageEvent(message, MessageDirection.THROW),
+    )
+
+    private fun catchNode(id: String, message: String) = FlowNodeDefinition(
+        id = id,
+        properties = FlowNodeProperties.MessageEvent(message, MessageDirection.CATCH),
+    )
+
+    private fun model(processId: String, vararg nodes: FlowNodeDefinition) =
+        testBpmnModel(processId = processId, flowNodes = nodes.toList())
+
+    private fun validate(vararg models: io.miragon.bpmn.domain.BpmnModel) =
+        underTest.validate(CrossModelValidationContext(models = models.toList(), engine = ProcessEngine.ZEEBE))
+
+    @Test
+    fun `warns on a thrown message that is never caught in the fileset`() {
+
+        // given: a single model that throws a message no one catches
+        val thrower = model("orderPlacement", throwNode("throw1", "OrderShipped"))
+
+        // when
+        val violations = validate(thrower)
+
+        // then: a single WARN naming the uncaught message and its throwing element
+        assertThat(violations).hasSize(1)
+        assertThat(violations[0].severity).isEqualTo(Severity.WARN)
+        assertThat(violations[0].elementId).isEqualTo("throw1")
+        assertThat(violations[0].processId).isEqualTo("orderPlacement")
+        assertThat(violations[0].message).contains("OrderShipped")
+    }
+
+    @Test
+    fun `no warning when a catcher exists in the same model`() {
+
+        // given: the throw and a matching catch live in one model
+        val model = model("orderPlacement", throwNode("throw1", "OrderShipped"), catchNode("catch1", "OrderShipped"))
+
+        // when
+        val violations = validate(model)
+
+        // then
+        assertThat(violations).isEmpty()
+    }
+
+    @Test
+    fun `no warning when the catcher lives in another loaded model`() {
+
+        // given: the message is thrown in one process and caught in another - the cross-model case
+        val thrower = model("orderPlacement", throwNode("throw1", "OrderShipped"))
+        val catcher = model("shipping", catchNode("catch1", "OrderShipped"))
+
+        // when
+        val violations = validate(thrower, catcher)
+
+        // then
+        assertThat(violations).isEmpty()
+    }
+
+    @Test
+    fun `warns only for the message whose catcher is missing`() {
+
+        // given: two thrown messages, only one of which is caught anywhere
+        val thrower = model("orderPlacement", throwNode("throw1", "OrderShipped"), throwNode("throw2", "OrderCancelled"))
+        val catcher = model("shipping", catchNode("catch1", "OrderShipped"))
+
+        // when
+        val violations = validate(thrower, catcher)
+
+        // then: only the uncaught message is reported
+        assertThat(violations).hasSize(1)
+        assertThat(violations[0].elementId).isEqualTo("throw2")
+        assertThat(violations[0].message).contains("OrderCancelled")
+    }
+}

--- a/bpmn-to-code-core/src/test/resources/json/MultiVariantNewsletterProcess.json
+++ b/bpmn-to-code-core/src/test/resources/json/MultiVariantNewsletterProcess.json
@@ -111,7 +111,12 @@
                     "parentId": "eventSubProcess_errorHandling",
                     "followingElements": [
                         "serviceTask_analyzeError"
-                    ]
+                    ],
+                    "properties": {
+                        "type": "MessageEvent",
+                        "messageName": "Message_MailRejected",
+                        "messageDirection": "CATCH"
+                    }
                 },
                 {
                     "id": "serviceTask_analyzeError",
@@ -184,7 +189,12 @@
                     ],
                     "followingElements": [
                         "escalationEndEvent_nofitySupportAfterRepeatedError"
-                    ]
+                    ],
+                    "properties": {
+                        "type": "MessageEvent",
+                        "messageName": "Message_MailRejectedAgain",
+                        "messageDirection": "CATCH"
+                    }
                 },
                 {
                     "id": "escalationEndEvent_nofitySupportAfterRepeatedError",

--- a/bpmn-to-code-core/src/test/resources/json/NewsletterSubscriptionProcess.json
+++ b/bpmn-to-code-core/src/test/resources/json/NewsletterSubscriptionProcess.json
@@ -10,7 +10,12 @@
             ],
             "variables": [
                 "subscriptionId"
-            ]
+            ],
+            "properties": {
+                "type": "MessageEvent",
+                "messageName": "Message_FormSubmitted",
+                "messageDirection": "CATCH"
+            }
         },
         {
             "id": "serviceTask_incrementSubscriptionCounter",

--- a/bpmn-to-code-testing/src/main/kotlin/io/miragon/bpmn/testing/BpmnRules.kt
+++ b/bpmn-to-code-testing/src/main/kotlin/io/miragon/bpmn/testing/BpmnRules.kt
@@ -15,6 +15,7 @@ import io.miragon.bpmn.domain.validation.rules.MissingSignalNameRule
 import io.miragon.bpmn.domain.validation.rules.MissingTimerDefinitionRule
 import io.miragon.bpmn.domain.validation.rules.TimerCronSyntaxRule
 import io.miragon.bpmn.domain.validation.rules.TimerIso8601SyntaxRule
+import io.miragon.bpmn.domain.validation.rules.UncaughtMessageThrowRule
 
 /**
  * Provides access to all built-in BPMN validation rules.
@@ -118,6 +119,15 @@ object BpmnRules {
      */
     @JvmField
     val CALL_ACTIVITY_TARGET_EXISTS: CrossModelValidationRule = CallActivityTargetExistsRule()
+
+    /**
+     * Opt-in: warns when a message is thrown (message end / intermediate throw event) but never caught
+     * anywhere in the loaded fileset. Cross-model — only meaningful when the whole related fileset is
+     * loaded together, so it is not part of [all]. Reported as WARN, since a consumer outside the
+     * fileset is possible.
+     */
+    @JvmField
+    val UNCAUGHT_MESSAGE_THROW: CrossModelValidationRule = UncaughtMessageThrowRule()
 
     /**
      * Returns all built-in BPMN validation rules that are enabled by default.

--- a/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/BpmnRulesTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/BpmnRulesTest.kt
@@ -54,7 +54,10 @@ class BpmnRulesTest {
             BpmnRules.TIMER_CRON_SYNTAX,
             BpmnRules.TIMER_ISO8601_SYNTAX,
         )
-        assertThat(BpmnRules.all().map { it.id }).doesNotContain(BpmnRules.CALL_ACTIVITY_TARGET_EXISTS.id)
+        assertThat(BpmnRules.all().map { it.id }).doesNotContain(
+            BpmnRules.CALL_ACTIVITY_TARGET_EXISTS.id,
+            BpmnRules.UNCAUGHT_MESSAGE_THROW.id,
+        )
     }
 
     @Test
@@ -62,5 +65,6 @@ class BpmnRulesTest {
         assertThat(BpmnRules.TIMER_CRON_SYNTAX.id).isEqualTo("timer-cron-syntax")
         assertThat(BpmnRules.TIMER_ISO8601_SYNTAX.id).isEqualTo("timer-iso8601-syntax")
         assertThat(BpmnRules.CALL_ACTIVITY_TARGET_EXISTS.id).isEqualTo("call-activity-target-exists")
+        assertThat(BpmnRules.UNCAUGHT_MESSAGE_THROW.id).isEqualTo("uncaught-message-throw")
     }
 }

--- a/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/CrossModelRuleTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/CrossModelRuleTest.kt
@@ -35,4 +35,28 @@ class CrossModelRuleTest {
             .validate()
             .assertNoViolations()
     }
+
+    @Test
+    fun `warns when a thrown message has no catcher among the loaded models`() {
+        BpmnValidator
+            .fromClasspath("bpmn/message-flow/order-shipping.bpmn")
+            .engine(ProcessEngine.CAMUNDA_7)
+            .withRules(BpmnRules.UNCAUGHT_MESSAGE_THROW)
+            .validate()
+            .assertViolation(
+                ruleId = BpmnRules.UNCAUGHT_MESSAGE_THROW.id,
+                elementId = "EndEvent_OrderShipped",
+                messageContains = "OrderShipped",
+            )
+    }
+
+    @Test
+    fun `passes when the thrown message is caught by another loaded model`() {
+        BpmnValidator
+            .fromClasspath("bpmn/message-flow/")
+            .engine(ProcessEngine.CAMUNDA_7)
+            .withRules(BpmnRules.UNCAUGHT_MESSAGE_THROW)
+            .validate()
+            .assertNoViolations()
+    }
 }

--- a/bpmn-to-code-testing/src/test/resources/bpmn/message-flow/order-shipping.bpmn
+++ b/bpmn-to-code-testing/src/test/resources/bpmn/message-flow/order-shipping.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  id="Definitions_OrderShipping"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:message id="Message_OrderShipped" name="OrderShipped" />
+  <bpmn:process id="orderShipping" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_OrderShipping" name="Order ready">
+      <bpmn:outgoing>Flow_ToShipped</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_OrderShipped" name="Order shipped">
+      <bpmn:incoming>Flow_ToShipped</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_OrderShipped" messageRef="Message_OrderShipped" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_ToShipped" sourceRef="StartEvent_OrderShipping" targetRef="EndEvent_OrderShipped" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="orderShipping">
+      <bpmndi:BPMNShape id="StartEvent_OrderShipping_di" bpmnElement="StartEvent_OrderShipping">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_OrderShipped_di" bpmnElement="EndEvent_OrderShipped">
+        <dc:Bounds x="292" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_ToShipped_di" bpmnElement="Flow_ToShipped">
+        <di:waypoint x="188" y="100" />
+        <di:waypoint x="292" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpmn-to-code-testing/src/test/resources/bpmn/message-flow/shipping-notification.bpmn
+++ b/bpmn-to-code-testing/src/test/resources/bpmn/message-flow/shipping-notification.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  id="Definitions_ShippingNotification"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:message id="Message_OrderShipped" name="OrderShipped" />
+  <bpmn:process id="shippingNotification" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_OrderShipped" name="Order shipped">
+      <bpmn:outgoing>Flow_ToNotify</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_OrderShippedCatch" messageRef="Message_OrderShipped" />
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_CustomerNotified" name="Customer notified">
+      <bpmn:incoming>Flow_ToNotify</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_ToNotify" sourceRef="StartEvent_OrderShipped" targetRef="EndEvent_CustomerNotified" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="shippingNotification">
+      <bpmndi:BPMNShape id="StartEvent_OrderShipped_di" bpmnElement="StartEvent_OrderShipped">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_CustomerNotified_di" bpmnElement="EndEvent_CustomerNotified">
+        <dc:Bounds x="292" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_ToNotify_di" bpmnElement="Flow_ToNotify">
+        <di:waypoint x="188" y="100" />
+        <di:waypoint x="292" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/docs/validate/testing.md
+++ b/docs/validate/testing.md
@@ -133,15 +133,16 @@ result.assertNoViolations("empty-process")  // custom: assert a specific rule pr
 
 ## Optional Rules (opt-in)
 
-These rules are **not** part of `BpmnRules.all()` — they are off by default. Enable them explicitly via `withRules(...)` when you want to enforce the corresponding convention. They report as `ERROR` when enabled.
+These rules are **not** part of `BpmnRules.all()` — they are off by default. Enable them explicitly via `withRules(...)` when you want to enforce the corresponding convention. Each rule's severity is listed below.
 
 | Rule | `BpmnRules` constant | Severity | Trigger |
 |------|---------------------|----------|---------|
 | Timer cycle is not valid cron | `TIMER_CRON_SYNTAX` | ERROR | A `timeCycle` timer whose value is not a valid cron expression |
 | Timer value is not valid ISO-8601 | `TIMER_ISO8601_SYNTAX` | ERROR | A timer value that is not valid ISO-8601 for its type (Date → date/time, Duration → duration, Cycle → repeating interval) |
 | Call activity target is missing | `CALL_ACTIVITY_TARGET_EXISTS` | ERROR | A call activity references a process that is not among the loaded models (a dangling call activity) |
+| Thrown message has no catcher | `UNCAUGHT_MESSAGE_THROW` | WARN | A message is thrown (message end / intermediate throw event) but no catching event exists among the loaded models |
 
-`CALL_ACTIVITY_TARGET_EXISTS` is a [cross-model rule](#cross-process-multi-model-rules): it only holds when the **whole** related fileset is loaded together, which is exactly why it is opt-in rather than part of `all()` — see the tip on loading the whole set below.
+`CALL_ACTIVITY_TARGET_EXISTS` and `UNCAUGHT_MESSAGE_THROW` are [cross-model rules](#cross-process-multi-model-rules): they only hold when the **whole** related fileset is loaded together, which is exactly why they are opt-in rather than part of `all()` — see the tip on loading the whole set below. `UNCAUGHT_MESSAGE_THROW` reports as **WARN** rather than ERROR because a legitimate consumer may live outside the loaded fileset; a catcher is any message start / intermediate-catch / boundary event or receive task, in any loaded model.
 
 ```kotlin
 BpmnValidator
@@ -331,8 +332,12 @@ single-model rule reports an `ERROR`, validation stops before the merge and the 
 runs (post-merge rules like `COLLISION_DETECTION` do not short-circuit it).
 :::
 
+Message correlation across processes already ships built-in as the opt-in `UNCAUGHT_MESSAGE_THROW` rule
+(see [Optional Rules](#optional-rules-opt-in)) — it collects every thrown message name across all loaded
+models and warns when one has no catching event anywhere in the set.
+
 Other cross-process checks you can write with the same building blocks: input-coverage ("does every
-caller pass the variables the called process reads?"), output-consumption, message/signal correlation
+caller pass the variables the called process reads?"), output-consumption, signal correlation
 across processes, and process-id uniqueness across the whole fileset.
 
 ::: tip SingleModelValidationContext


### PR DESCRIPTION
Closes #49.

## Summary

Warns when a message is thrown but never caught anywhere in the loaded fileset — silently lost cross-process communication that no single-model rule can detect.

- **Domain:** new `FlowNodeProperties.MessageEvent(name, direction)` + `MessageDirection { THROW, CATCH }`, coupling each message-bearing node to its name and role. Populated in the C7, Zeebe and Operaton extractors via a shared `MessageUtils.findMessageEventProperties()` helper (role derived from event shape; receive tasks are catchers). Additive — the existing `messages` list and its codegen/merge/JSON consumers are untouched.
- **Rule:** `UncaughtMessageThrowRule` (`uncaught-message-throw`), an opt-in, **WARN**-severity `CrossModelValidationRule`. Collects caught message names across all models and warns for each thrown name with no catcher. Registered as `BpmnRules.UNCAUGHT_MESSAGE_THROW` (not in `all()`).
- **WARN, not ERROR:** a legitimate consumer may live outside the loaded fileset.

## Notes

- An implemented message-throw event (Camunda delegate/topic/etc.) still resolves to `ServiceTask` (codegen depends on it), so the rule only flags plain throws. Nameless message events are skipped — the concern of `missing-message-name`.
- Modeled the throw/catch **role** (`direction`) rather than the raw `EventShape` the issue sketched: `EventShape` would duplicate `nodeType.Event.shape` and can't represent receive tasks (which count as catchers).

## Tests

- Core unit test (`UncaughtMessageThrowRuleTest`), extractor fixtures updated across all three engines (incl. a receive-task catcher and an implemented throw), integration test with a new `message-flow/` fixture pair, and registration assertions in `BpmnRulesTest`.
- Docs updated in `docs/validate/testing.md`.

`./gradlew build` passes (all module tests + detekt).