### PR TITLE
feat(testing): add opt-in signal cross-model rules

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
@@ -15,6 +15,7 @@ import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findFlow
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSequenceFlows
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSignalEventDefinitions
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findTimerEventDefinition
+import io.miragon.bpmn.adapter.outbound.engine.utils.SignalUtils.findSignalEventProperties
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.extractVariantName
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.getProcessId
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.isExecutable
@@ -67,14 +68,15 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
         val variablesPerNode = extractVariablesPerNode(modelInstance)
 
         val asyncPerNode = extractAsyncPerNode(modelInstance)
-        val messageEvents = modelInstance.findMessageEventProperties()
+        val eventProperties: Map<String, FlowNodeProperties> =
+            modelInstance.findMessageEventProperties() + modelInstance.findSignalEventProperties()
         val allServiceTasks = serviceTasks + messageSendEvents
         val enrichedFlowNodes = enrichFlowNodes(
             flowNodes = allFlowNodes,
             serviceTasks = allServiceTasks,
             callActivities = callActivities,
             timers = timers,
-            messageEvents = messageEvents,
+            eventProperties = eventProperties,
             variablesPerNode = variablesPerNode,
             asyncPerNode = asyncPerNode,
         )
@@ -99,7 +101,7 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
         serviceTasks: List<ServiceTaskDefinition>,
         callActivities: List<CallActivityDefinition>,
         timers: List<TimerDefinition>,
-        messageEvents: Map<String, FlowNodeProperties.MessageEvent>,
+        eventProperties: Map<String, FlowNodeProperties>,
         variablesPerNode: Map<String?, List<VariableDefinition>>,
         asyncPerNode: Map<String?, Map<String, Any?>>,
     ): List<FlowNodeDefinition> {
@@ -111,7 +113,7 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
             .groupBy { it.attachedToRef!! }
             .mapValues { (_, nodes) -> nodes.mapNotNull { it.id } }
         return flowNodes.map { node ->
-            val properties = resolveProperties(node.id, serviceTaskById, callActivityById, timerById, messageEvents)
+            val properties = resolveProperties(node.id, serviceTaskById, callActivityById, timerById, eventProperties)
             val variables = variablesPerNode[node.id] ?: emptyList()
             val attachedElements = attachedElementsById[node.id] ?: emptyList()
             val engineSpecificProperties = asyncPerNode[node.id] ?: emptyMap()
@@ -141,12 +143,12 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
         serviceTasks: Map<String?, ServiceTaskDefinition>,
         callActivities: Map<String?, CallActivityDefinition>,
         timers: Map<String?, TimerDefinition>,
-        messageEvents: Map<String, FlowNodeProperties.MessageEvent>,
+        eventProperties: Map<String, FlowNodeProperties>,
     ): FlowNodeProperties {
         serviceTasks[nodeId]?.let { return FlowNodeProperties.ServiceTask(it) }
         callActivities[nodeId]?.let { return FlowNodeProperties.CallActivity(it) }
         timers[nodeId]?.let { return FlowNodeProperties.Timer(it) }
-        return nodeId?.let { messageEvents[it] } ?: FlowNodeProperties.None
+        return nodeId?.let { eventProperties[it] } ?: FlowNodeProperties.None
     }
 
     private fun findMessages(modelInstance: ModelInstance): List<MessageDefinition> {

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
@@ -14,6 +14,7 @@ import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findEsca
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findFlowNodes
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSequenceFlows
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSignalEventDefinitions
+import io.miragon.bpmn.adapter.outbound.engine.utils.SignalUtils.findSignalEventProperties
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findTimerEventDefinition
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.extractVariantName
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.getProcessId
@@ -71,14 +72,15 @@ class OperatonModelExtractor : EngineSpecificExtractor {
         val variablesPerNode = extractVariablesPerNode(modelInstance)
 
         val asyncPerNode = extractAsyncPerNode(modelInstance)
-        val messageEvents = modelInstance.findMessageEventProperties()
+        val eventProperties: Map<String, FlowNodeProperties> =
+            modelInstance.findMessageEventProperties() + modelInstance.findSignalEventProperties()
         val allServiceTasks = serviceTasks + messageSendEvents
         val enrichedFlowNodes = enrichFlowNodes(
             flowNodes = flowNodes,
             serviceTasks = allServiceTasks,
             callActivities = callActivities,
             timers = timers,
-            messageEvents = messageEvents,
+            eventProperties = eventProperties,
             variablesPerNode = variablesPerNode,
             asyncPerNode = asyncPerNode,
         )
@@ -103,7 +105,7 @@ class OperatonModelExtractor : EngineSpecificExtractor {
         serviceTasks: List<ServiceTaskDefinition>,
         callActivities: List<CallActivityDefinition>,
         timers: List<TimerDefinition>,
-        messageEvents: Map<String, FlowNodeProperties.MessageEvent>,
+        eventProperties: Map<String, FlowNodeProperties>,
         variablesPerNode: Map<String?, List<VariableDefinition>>,
         asyncPerNode: Map<String?, Map<String, Any?>>,
     ): List<FlowNodeDefinition> {
@@ -115,7 +117,7 @@ class OperatonModelExtractor : EngineSpecificExtractor {
             .groupBy { it.attachedToRef!! }
             .mapValues { (_, nodes) -> nodes.mapNotNull { it.id } }
         return flowNodes.map { node ->
-            val properties = resolveProperties(node.id, serviceTaskById, callActivityById, timerById, messageEvents)
+            val properties = resolveProperties(node.id, serviceTaskById, callActivityById, timerById, eventProperties)
             val variables = variablesPerNode[node.id] ?: emptyList()
             val attachedElements = attachedElementsById[node.id] ?: emptyList()
             val engineSpecificProperties = asyncPerNode[node.id] ?: emptyMap()
@@ -144,12 +146,12 @@ class OperatonModelExtractor : EngineSpecificExtractor {
         serviceTasks: Map<String?, ServiceTaskDefinition>,
         callActivities: Map<String?, CallActivityDefinition>,
         timers: Map<String?, TimerDefinition>,
-        messageEvents: Map<String, FlowNodeProperties.MessageEvent>,
+        eventProperties: Map<String, FlowNodeProperties>,
     ): FlowNodeProperties {
         serviceTasks[nodeId]?.let { return FlowNodeProperties.ServiceTask(it) }
         callActivities[nodeId]?.let { return FlowNodeProperties.CallActivity(it) }
         timers[nodeId]?.let { return FlowNodeProperties.Timer(it) }
-        return nodeId?.let { messageEvents[it] } ?: FlowNodeProperties.None
+        return nodeId?.let { eventProperties[it] } ?: FlowNodeProperties.None
     }
 
     private fun findMessages(modelInstance: ModelInstance): List<MessageDefinition> {

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
@@ -17,6 +17,7 @@ import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findEsca
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findFlowNodes
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSequenceFlows
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSignalEventDefinitions
+import io.miragon.bpmn.adapter.outbound.engine.utils.SignalUtils.findSignalEventProperties
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findTimerEventDefinition
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.extractVariantName
 import io.miragon.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.getProcessId
@@ -60,14 +61,15 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
         val allServiceTasks = findServiceTasks(modelInstance)
         val allCallActivities = findCallActivities(modelInstance)
         val variablesPerNode = extractVariablesPerNode(modelInstance)
-        val messageEvents = modelInstance.findMessageEventProperties()
+        val eventProperties: Map<String, FlowNodeProperties> =
+            modelInstance.findMessageEventProperties() + modelInstance.findSignalEventProperties()
 
         val enrichedFlowNodes = enrichFlowNodes(
             flowNodes = allFlowNodes,
             serviceTasks = allServiceTasks,
             callActivities = allCallActivities,
             timers = allTimerEvents,
-            messageEvents = messageEvents,
+            eventProperties = eventProperties,
             variablesPerNode = variablesPerNode,
         )
 
@@ -91,7 +93,7 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
         serviceTasks: List<ServiceTaskDefinition>,
         callActivities: List<CallActivityDefinition>,
         timers: List<io.miragon.bpmn.domain.shared.TimerDefinition>,
-        messageEvents: Map<String, FlowNodeProperties.MessageEvent>,
+        eventProperties: Map<String, FlowNodeProperties>,
         variablesPerNode: Map<String?, List<VariableDefinition>>,
     ): List<FlowNodeDefinition> {
         val serviceTaskById = serviceTasks.associateBy { it.id }
@@ -102,7 +104,7 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
             .groupBy { it.attachedToRef!! }
             .mapValues { (_, nodes) -> nodes.mapNotNull { it.id } }
         return flowNodes.map { node ->
-            val properties = resolveProperties(node.id, serviceTaskById, callActivityById, timerById, messageEvents)
+            val properties = resolveProperties(node.id, serviceTaskById, callActivityById, timerById, eventProperties)
             val variables = variablesPerNode[node.id] ?: emptyList()
             val attachedElements = attachedElementsById[node.id] ?: emptyList()
             node.copy(properties = properties, variables = variables, attachedElements = attachedElements)
@@ -114,12 +116,12 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
         serviceTasks: Map<String?, ServiceTaskDefinition>,
         callActivities: Map<String?, CallActivityDefinition>,
         timers: Map<String?, io.miragon.bpmn.domain.shared.TimerDefinition>,
-        messageEvents: Map<String, FlowNodeProperties.MessageEvent>,
+        eventProperties: Map<String, FlowNodeProperties>,
     ): FlowNodeProperties {
         serviceTasks[nodeId]?.let { return FlowNodeProperties.ServiceTask(it) }
         callActivities[nodeId]?.let { return FlowNodeProperties.CallActivity(it) }
         timers[nodeId]?.let { return FlowNodeProperties.Timer(it) }
-        return nodeId?.let { messageEvents[it] } ?: FlowNodeProperties.None
+        return nodeId?.let { eventProperties[it] } ?: FlowNodeProperties.None
     }
 
     private fun findCallActivities(modelInstance: ModelInstance): List<CallActivityDefinition> {

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/utils/EventDirectionUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/utils/EventDirectionUtils.kt
@@ -1,0 +1,19 @@
+package io.miragon.bpmn.adapter.outbound.engine.utils
+
+import io.miragon.bpmn.domain.shared.EventDirection
+
+/**
+ * Maps a BPMN event element type name to its throw/catch role, shared by message and signal extraction.
+ * End / intermediate-throw events send; start / intermediate-catch / boundary events receive. Any other
+ * element type carries no throw/catch role and yields `null`.
+ */
+object EventDirectionUtils {
+
+    fun fromElementTypeName(typeName: String): EventDirection? {
+        return when (typeName) {
+            "endEvent", "intermediateThrowEvent" -> EventDirection.THROW
+            "startEvent", "intermediateCatchEvent", "boundaryEvent" -> EventDirection.CATCH
+            else -> null
+        }
+    }
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/utils/MessageUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/utils/MessageUtils.kt
@@ -1,8 +1,8 @@
 package io.miragon.bpmn.adapter.outbound.engine.utils
 
 import io.miragon.bpmn.adapter.outbound.engine.helpers.MessageSource
+import io.miragon.bpmn.domain.shared.EventDirection
 import io.miragon.bpmn.domain.shared.FlowNodeProperties
-import io.miragon.bpmn.domain.shared.MessageDirection
 import org.camunda.bpm.model.bpmn.impl.BpmnModelConstants
 import org.camunda.bpm.model.bpmn.instance.MessageEventDefinition
 import org.camunda.bpm.model.bpmn.instance.ReceiveTask
@@ -13,7 +13,7 @@ object MessageUtils {
     /**
      * Couples each message-bearing node to its message name and throw/catch role, keyed by element id.
      * Message events derive their role from the carrying event's shape (end / intermediate-throw =
-     * [MessageDirection.THROW]; start / intermediate-catch / boundary = [MessageDirection.CATCH]); a
+     * [EventDirection.THROW]; start / intermediate-catch / boundary = [EventDirection.CATCH]); a
      * receive task is always a catcher. Nameless message nodes are skipped — they carry no name to
      * correlate on and are the concern of the missing-message-name rule.
      */
@@ -23,22 +23,16 @@ object MessageUtils {
                 val name = med.message?.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_NAME) ?: return@mapNotNull null
                 val parent = med.parentElement ?: return@mapNotNull null
                 val elementId = parent.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID) ?: return@mapNotNull null
-                val direction = parent.elementType.typeName.toMessageDirection() ?: return@mapNotNull null
+                val direction = EventDirectionUtils.fromElementTypeName(parent.elementType.typeName) ?: return@mapNotNull null
                 elementId to FlowNodeProperties.MessageEvent(name, direction)
             }
         val fromTasks = this.getModelElementsByType(ReceiveTask::class.java)
             .mapNotNull { task ->
                 val name = task.message?.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_NAME) ?: return@mapNotNull null
                 val elementId = task.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID) ?: return@mapNotNull null
-                elementId to FlowNodeProperties.MessageEvent(name, MessageDirection.CATCH)
+                elementId to FlowNodeProperties.MessageEvent(name, EventDirection.CATCH)
             }
         return (fromEvents + fromTasks).toMap()
-    }
-
-    private fun String.toMessageDirection(): MessageDirection? = when (this) {
-        "endEvent", "intermediateThrowEvent" -> MessageDirection.THROW
-        "startEvent", "intermediateCatchEvent", "boundaryEvent" -> MessageDirection.CATCH
-        else -> null
     }
 
     fun ModelInstance.findEventBasedMessagesWithSource(): List<MessageSource> {

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/utils/SignalUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/engine/utils/SignalUtils.kt
@@ -1,0 +1,29 @@
+package io.miragon.bpmn.adapter.outbound.engine.utils
+
+import io.miragon.bpmn.domain.shared.EventDirection
+import io.miragon.bpmn.domain.shared.FlowNodeProperties
+import org.camunda.bpm.model.bpmn.impl.BpmnModelConstants
+import org.camunda.bpm.model.bpmn.instance.SignalEventDefinition
+import org.camunda.bpm.model.xml.ModelInstance
+
+object SignalUtils {
+
+    /**
+     * Couples each signal-bearing node to its signal name and throw/catch role, keyed by element id.
+     * Signal events derive their role from the carrying event's shape (end / intermediate-throw =
+     * [EventDirection.THROW]; start / intermediate-catch / boundary = [EventDirection.CATCH]). Nameless
+     * signal nodes are skipped — they carry no name to correlate on and are the concern of the
+     * missing-signal-name rule.
+     */
+    fun ModelInstance.findSignalEventProperties(): Map<String, FlowNodeProperties.SignalEvent> {
+        return this.getModelElementsByType(SignalEventDefinition::class.java)
+            .mapNotNull { sed ->
+                val name = sed.signal?.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_NAME) ?: return@mapNotNull null
+                val parent = sed.parentElement ?: return@mapNotNull null
+                val elementId = parent.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID) ?: return@mapNotNull null
+                val direction = EventDirectionUtils.fromElementTypeName(parent.elementType.typeName) ?: return@mapNotNull null
+                elementId to FlowNodeProperties.SignalEvent(name, direction)
+            }
+            .toMap()
+    }
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/json/BpmnJsonMapper.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/json/BpmnJsonMapper.kt
@@ -115,6 +115,11 @@ class BpmnJsonMapper {
             messageName = name,
             messageDirection = direction.name,
         )
+        is FlowNodeProperties.SignalEvent -> FlowNodePropertiesJson(
+            type = "SignalEvent",
+            signalName = name,
+            signalDirection = direction.name,
+        )
     }
 
     private fun SequenceFlowDefinition.toJson(): SequenceFlowJson {

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/json/model/FlowNodePropertiesJson.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/json/model/FlowNodePropertiesJson.kt
@@ -12,4 +12,6 @@ data class FlowNodePropertiesJson(
     val timerValue: String? = null,
     val messageName: String? = null,
     val messageDirection: String? = null,
+    val signalName: String? = null,
+    val signalDirection: String? = null,
 )

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/shared/EventDirection.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/shared/EventDirection.kt
@@ -1,0 +1,9 @@
+package io.miragon.bpmn.domain.shared
+
+/**
+ * Whether a message- or signal-bearing node throws (sends) or catches (receives) its event.
+ */
+enum class EventDirection {
+    THROW,
+    CATCH,
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/shared/FlowNodeProperties.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/shared/FlowNodeProperties.kt
@@ -5,5 +5,6 @@ sealed interface FlowNodeProperties {
     data class ServiceTask(val definition: ServiceTaskDefinition) : FlowNodeProperties
     data class Timer(val definition: TimerDefinition) : FlowNodeProperties
     data class CallActivity(val definition: CallActivityDefinition) : FlowNodeProperties
-    data class MessageEvent(val name: String, val direction: MessageDirection) : FlowNodeProperties
+    data class MessageEvent(val name: String, val direction: EventDirection) : FlowNodeProperties
+    data class SignalEvent(val name: String, val direction: EventDirection) : FlowNodeProperties
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/shared/MessageDirection.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/shared/MessageDirection.kt
@@ -1,9 +1,0 @@
-package io.miragon.bpmn.domain.shared
-
-/**
- * Whether a message-bearing node throws (sends) or catches (receives) its message.
- */
-enum class MessageDirection {
-    THROW,
-    CATCH,
-}

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/UncaughtMessageThrowRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/UncaughtMessageThrowRule.kt
@@ -3,7 +3,7 @@ package io.miragon.bpmn.domain.validation.rules
 import io.miragon.bpmn.domain.ProcessModel
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition
 import io.miragon.bpmn.domain.shared.FlowNodeProperties
-import io.miragon.bpmn.domain.shared.MessageDirection
+import io.miragon.bpmn.domain.shared.EventDirection
 import io.miragon.bpmn.domain.validation.CrossModelValidationRule
 import io.miragon.bpmn.domain.validation.model.CrossModelValidationContext
 import io.miragon.bpmn.domain.validation.model.Severity
@@ -44,19 +44,19 @@ class UncaughtMessageThrowRule : CrossModelValidationRule {
         context: CrossModelValidationContext,
     ): List<Triple<ProcessModel, FlowNodeDefinition, FlowNodeProperties.MessageEvent>> {
         return context.models.flatMap { model ->
-            model.messageEvents(MessageDirection.THROW).map { (node, message) -> Triple(model, node, message) }
+            model.messageEvents(EventDirection.THROW).map { (node, message) -> Triple(model, node, message) }
         }
     }
 
     private fun caughtMessageNames(context: CrossModelValidationContext): Set<String> {
         return context.models
-            .flatMap { model -> model.messageEvents(MessageDirection.CATCH) }
+            .flatMap { model -> model.messageEvents(EventDirection.CATCH) }
             .map { (_, message) -> message.name }
             .toSet()
     }
 
     private fun ProcessModel.messageEvents(
-        direction: MessageDirection,
+        direction: EventDirection,
     ): List<Pair<FlowNodeDefinition, FlowNodeProperties.MessageEvent>> {
         return flowNodes
             .mapNotNull { node -> node.messageEvent()?.let { node to it } }

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/UncaughtSignalThrowRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/UncaughtSignalThrowRule.kt
@@ -1,0 +1,69 @@
+package io.miragon.bpmn.domain.validation.rules
+
+import io.miragon.bpmn.domain.ProcessModel
+import io.miragon.bpmn.domain.shared.EventDirection
+import io.miragon.bpmn.domain.shared.FlowNodeDefinition
+import io.miragon.bpmn.domain.shared.FlowNodeProperties
+import io.miragon.bpmn.domain.validation.CrossModelValidationRule
+import io.miragon.bpmn.domain.validation.model.CrossModelValidationContext
+import io.miragon.bpmn.domain.validation.model.Severity
+import io.miragon.bpmn.domain.validation.model.ValidationViolation
+
+/**
+ * Flags a signal that is thrown (signal end / intermediate throw event) but never caught anywhere in
+ * the loaded fileset — a broadcast that goes nowhere, which no single-model rule can detect since the
+ * subscriber may live in another process file.
+ *
+ * Reported as WARN, not ERROR: signals are broadcast, so a legitimate subscriber outside the loaded
+ * fileset is possible and the rule can only warn. Cross-model — only meaningful with the whole related
+ * fileset loaded together, so it is opt-in (see BpmnRules).
+ */
+class UncaughtSignalThrowRule : CrossModelValidationRule {
+
+    override val id = "uncaught-signal-throw"
+    override val severity = Severity.WARN
+
+    override fun validate(context: CrossModelValidationContext): List<ValidationViolation> {
+        val thrownSignals = thrownSignals(context)
+        val caughtSignalNames = caughtSignalNames(context)
+
+        return thrownSignals
+            .filterNot { (_, _, signal) -> signal.name in caughtSignalNames }
+            .map { (model, node, signal) ->
+                ValidationViolation(
+                    ruleId = id,
+                    severity = severity,
+                    elementId = node.id,
+                    processId = model.processId,
+                    message = "Signal '${signal.name}' is thrown by '${node.id}' but has no catching event in the loaded models.",
+                )
+            }
+    }
+
+    private fun thrownSignals(
+        context: CrossModelValidationContext,
+    ): List<Triple<ProcessModel, FlowNodeDefinition, FlowNodeProperties.SignalEvent>> {
+        return context.models.flatMap { model ->
+            model.signalEvents(EventDirection.THROW).map { (node, signal) -> Triple(model, node, signal) }
+        }
+    }
+
+    private fun caughtSignalNames(context: CrossModelValidationContext): Set<String> {
+        return context.models
+            .flatMap { model -> model.signalEvents(EventDirection.CATCH) }
+            .map { (_, signal) -> signal.name }
+            .toSet()
+    }
+
+    private fun ProcessModel.signalEvents(
+        direction: EventDirection,
+    ): List<Pair<FlowNodeDefinition, FlowNodeProperties.SignalEvent>> {
+        return flowNodes
+            .mapNotNull { node -> node.signalEvent()?.let { node to it } }
+            .filter { (_, signal) -> signal.direction == direction }
+    }
+
+    private fun FlowNodeDefinition.signalEvent(): FlowNodeProperties.SignalEvent? {
+        return properties as? FlowNodeProperties.SignalEvent
+    }
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/UnpublishedSignalCatchRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/UnpublishedSignalCatchRule.kt
@@ -1,0 +1,70 @@
+package io.miragon.bpmn.domain.validation.rules
+
+import io.miragon.bpmn.domain.ProcessModel
+import io.miragon.bpmn.domain.shared.EventDirection
+import io.miragon.bpmn.domain.shared.FlowNodeDefinition
+import io.miragon.bpmn.domain.shared.FlowNodeProperties
+import io.miragon.bpmn.domain.validation.CrossModelValidationRule
+import io.miragon.bpmn.domain.validation.model.CrossModelValidationContext
+import io.miragon.bpmn.domain.validation.model.Severity
+import io.miragon.bpmn.domain.validation.model.ValidationViolation
+
+/**
+ * Flags a signal that is caught (signal start / intermediate catch / boundary event) but never thrown
+ * anywhere in the loaded fileset — an orphaned subscriber waiting for a broadcast that no process
+ * publishes. The mirror of [UncaughtSignalThrowRule]; no single-model rule can detect it since the
+ * thrower may live in another process file.
+ *
+ * Reported as WARN, not ERROR: signals are broadcast, so a legitimate publisher outside the loaded
+ * fileset is possible and the rule can only warn. Cross-model — only meaningful with the whole related
+ * fileset loaded together, so it is opt-in (see BpmnRules).
+ */
+class UnpublishedSignalCatchRule : CrossModelValidationRule {
+
+    override val id = "unpublished-signal-catch"
+    override val severity = Severity.WARN
+
+    override fun validate(context: CrossModelValidationContext): List<ValidationViolation> {
+        val caughtSignals = caughtSignals(context)
+        val thrownSignalNames = thrownSignalNames(context)
+
+        return caughtSignals
+            .filterNot { (_, _, signal) -> signal.name in thrownSignalNames }
+            .map { (model, node, signal) ->
+                ValidationViolation(
+                    ruleId = id,
+                    severity = severity,
+                    elementId = node.id,
+                    processId = model.processId,
+                    message = "Signal '${signal.name}' is caught by '${node.id}' but has no throwing event in the loaded models.",
+                )
+            }
+    }
+
+    private fun caughtSignals(
+        context: CrossModelValidationContext,
+    ): List<Triple<ProcessModel, FlowNodeDefinition, FlowNodeProperties.SignalEvent>> {
+        return context.models.flatMap { model ->
+            model.signalEvents(EventDirection.CATCH).map { (node, signal) -> Triple(model, node, signal) }
+        }
+    }
+
+    private fun thrownSignalNames(context: CrossModelValidationContext): Set<String> {
+        return context.models
+            .flatMap { model -> model.signalEvents(EventDirection.THROW) }
+            .map { (_, signal) -> signal.name }
+            .toSet()
+    }
+
+    private fun ProcessModel.signalEvents(
+        direction: EventDirection,
+    ): List<Pair<FlowNodeDefinition, FlowNodeProperties.SignalEvent>> {
+        return flowNodes
+            .mapNotNull { node -> node.signalEvent()?.let { node to it } }
+            .filter { (_, signal) -> signal.direction == direction }
+    }
+
+    private fun FlowNodeDefinition.signalEvent(): FlowNodeProperties.SignalEvent? {
+        return properties as? FlowNodeProperties.SignalEvent
+    }
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -15,7 +15,7 @@ import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_AFTER_KE
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_BEFORE_KEY
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.EXCLUSIVE_KEY
 import io.miragon.bpmn.domain.shared.FlowNodeProperties
-import io.miragon.bpmn.domain.shared.MessageDirection
+import io.miragon.bpmn.domain.shared.EventDirection
 import io.miragon.bpmn.domain.shared.SequenceFlowDefinition
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL_KIND_KEY
@@ -111,6 +111,7 @@ class Camunda7ModelExtractorTest {
                         previousElements = listOf("Activity_SendWelcomeMail")),
                     FlowNodeDefinition("EndEvent_RegistrationNotPossible", BpmnNodeType.Event(EventShape.END_EVENT, EventDefinitionType.SIGNAL),
                         displayName = "Registration not possible",
+                        properties = FlowNodeProperties.SignalEvent("Signal_RegistrationNotPossible", EventDirection.THROW),
                         previousElements = listOf("ErrorEvent_InvalidMail"),
                         engineSpecificProperties = mapOf(ASYNC_BEFORE_KEY to true, EXCLUSIVE_KEY to false)),
                     FlowNodeDefinition("EndEvent_SubscriptionConfirmed", BpmnNodeType.Event(EventShape.END_EVENT),
@@ -135,7 +136,7 @@ class Camunda7ModelExtractorTest {
                         engineSpecificProperties = mapOf(ASYNC_BEFORE_KEY to true)),
                     FlowNodeDefinition("StartEvent_SubmitRegistrationForm", BpmnNodeType.Event(EventShape.START_EVENT, EventDefinitionType.MESSAGE),
                         displayName = "Submit newsletter form",
-                        properties = FlowNodeProperties.MessageEvent("Message_FormSubmitted", MessageDirection.CATCH),
+                        properties = FlowNodeProperties.MessageEvent("Message_FormSubmitted", EventDirection.CATCH),
                         variables = listOf(VariableDefinition("subscriptionId", VariableDirection.OUTPUT, "\${subscriptionId}")),
                         followingElements = listOf("serviceTask_incrementSubscriptionCounter")),
                     FlowNodeDefinition("SubProcess_Confirmation", BpmnNodeType.Activity.SubProcess(SubProcessKind.PLAIN),

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -15,7 +15,7 @@ import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_AFTER_KE
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_BEFORE_KEY
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.EXCLUSIVE_KEY
 import io.miragon.bpmn.domain.shared.FlowNodeProperties
-import io.miragon.bpmn.domain.shared.MessageDirection
+import io.miragon.bpmn.domain.shared.EventDirection
 import io.miragon.bpmn.domain.shared.SequenceFlowDefinition
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL_KIND_KEY
@@ -110,6 +110,7 @@ class OperatonModelExtractorTest {
                         previousElements = listOf("Activity_SendWelcomeMail")),
                     FlowNodeDefinition("EndEvent_RegistrationNotPossible", BpmnNodeType.Event(EventShape.END_EVENT, EventDefinitionType.SIGNAL),
                         displayName = "Registration not possible",
+                        properties = FlowNodeProperties.SignalEvent("Signal_RegistrationNotPossible", EventDirection.THROW),
                         previousElements = listOf("ErrorEvent_InvalidMail"),
                         engineSpecificProperties = mapOf(ASYNC_BEFORE_KEY to true, EXCLUSIVE_KEY to false)),
                     FlowNodeDefinition("EndEvent_SubscriptionConfirmed", BpmnNodeType.Event(EventShape.END_EVENT),
@@ -134,7 +135,7 @@ class OperatonModelExtractorTest {
                         engineSpecificProperties = mapOf(ASYNC_BEFORE_KEY to true)),
                     FlowNodeDefinition("StartEvent_SubmitRegistrationForm", BpmnNodeType.Event(EventShape.START_EVENT, EventDefinitionType.MESSAGE),
                         displayName = "Submit newsletter form",
-                        properties = FlowNodeProperties.MessageEvent("Message_FormSubmitted", MessageDirection.CATCH),
+                        properties = FlowNodeProperties.MessageEvent("Message_FormSubmitted", EventDirection.CATCH),
                         variables = listOf(VariableDefinition("subscriptionId", VariableDirection.OUTPUT, "\${subscriptionId}")),
                         followingElements = listOf("serviceTask_incrementSubscriptionCounter")),
                     FlowNodeDefinition("SubProcess_Confirmation", BpmnNodeType.Activity.SubProcess(SubProcessKind.PLAIN),

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -13,7 +13,7 @@ import io.miragon.bpmn.domain.shared.EscalationDefinition
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition
 import io.miragon.bpmn.domain.shared.FlowNodeProperties
 import io.miragon.bpmn.domain.shared.MessageDefinition
-import io.miragon.bpmn.domain.shared.MessageDirection
+import io.miragon.bpmn.domain.shared.EventDirection
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL_KIND_KEY
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL_VALUE_KEY
@@ -69,7 +69,7 @@ class ZeebeModelExtractorTest {
                         followingElements = listOf("CompensationEndEvent_RegistrationAborted")),
                     FlowNodeDefinition("Activity_ConfirmRegistration", BpmnNodeType.Activity.Task(TaskKind.RECEIVE),
                         displayName = "Confirm subscription",
-                        properties = FlowNodeProperties.MessageEvent("Message_SubscriptionConfirmed", MessageDirection.CATCH),
+                        properties = FlowNodeProperties.MessageEvent("Message_SubscriptionConfirmed", EventDirection.CATCH),
                         attachedElements = listOf("Timer_EveryDay"),
                         parentId = "SubProcess_Confirmation",
                         previousElements = listOf("Activity_SendConfirmationMail"),
@@ -106,6 +106,7 @@ class ZeebeModelExtractorTest {
                         previousElements = listOf("Activity_SendWelcomeMail")),
                     FlowNodeDefinition("EndEvent_RegistrationNotPossible", BpmnNodeType.Event(EventShape.END_EVENT, EventDefinitionType.SIGNAL),
                         displayName = "Registration not possible",
+                        properties = FlowNodeProperties.SignalEvent("Signal_RegistrationNotPossible", EventDirection.THROW),
                         previousElements = listOf("ErrorEvent_InvalidMail")),
                     FlowNodeDefinition("EndEvent_SubscriptionConfirmed", BpmnNodeType.Event(EventShape.END_EVENT),
                         displayName = "Subscription confirmed",
@@ -129,7 +130,7 @@ class ZeebeModelExtractorTest {
                         followingElements = listOf("Activity_SendConfirmationMail")),
                     FlowNodeDefinition("StartEvent_SubmitRegistrationForm", BpmnNodeType.Event(EventShape.START_EVENT, EventDefinitionType.MESSAGE),
                         displayName = "Submit newsletter form",
-                        properties = FlowNodeProperties.MessageEvent("Message_FormSubmitted", MessageDirection.CATCH),
+                        properties = FlowNodeProperties.MessageEvent("Message_FormSubmitted", EventDirection.CATCH),
                         variables = listOf(VariableDefinition("subscriptionId", VariableDirection.OUTPUT, "=subscriptionId")),
                         followingElements = listOf("serviceTask_incrementSubscriptionCounter")),
                     FlowNodeDefinition("SubProcess_Confirmation", BpmnNodeType.Activity.SubProcess(SubProcessKind.PLAIN),

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/TestBpmnModel.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/TestBpmnModel.kt
@@ -17,7 +17,7 @@ import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_BEFORE_K
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition.Companion.EXCLUSIVE_KEY
 import io.miragon.bpmn.domain.shared.FlowNodeProperties
 import io.miragon.bpmn.domain.shared.MessageDefinition
-import io.miragon.bpmn.domain.shared.MessageDirection
+import io.miragon.bpmn.domain.shared.EventDirection
 import io.miragon.bpmn.domain.shared.OutputLanguage
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.shared.ServiceTaskDefinition
@@ -105,6 +105,7 @@ fun testSubscribeNewsletterBpmnModel(
             previousElements = listOf("Activity_SendWelcomeMail")),
         FlowNodeDefinition("EndEvent_RegistrationNotPossible", BpmnNodeType.Event(EventShape.END_EVENT, EventDefinitionType.SIGNAL),
             displayName = "Registration not possible",
+            properties = FlowNodeProperties.SignalEvent("Signal_RegistrationNotPossible", EventDirection.THROW),
             previousElements = listOf("ErrorEvent_InvalidMail")),
         FlowNodeDefinition("EndEvent_SubscriptionConfirmed", BpmnNodeType.Event(EventShape.END_EVENT),
             displayName = "Subscription confirmed",
@@ -126,7 +127,7 @@ fun testSubscribeNewsletterBpmnModel(
             followingElements = listOf("Activity_SendConfirmationMail")),
         FlowNodeDefinition("StartEvent_SubmitRegistrationForm", BpmnNodeType.Event(EventShape.START_EVENT, EventDefinitionType.MESSAGE),
             displayName = "Submit newsletter form",
-            properties = FlowNodeProperties.MessageEvent("Message_FormSubmitted", MessageDirection.CATCH),
+            properties = FlowNodeProperties.MessageEvent("Message_FormSubmitted", EventDirection.CATCH),
             variables = listOf(VariableDefinition("subscriptionId", VariableDirection.OUTPUT)),
             followingElements = listOf("serviceTask_incrementSubscriptionCounter")),
         FlowNodeDefinition("SubProcess_Confirmation", BpmnNodeType.Activity.SubProcess(SubProcessKind.PLAIN),
@@ -212,7 +213,7 @@ fun testSendNewsletterBpmnModel(
         // Event subprocess: error handling
         FlowNodeDefinition("eventSubProcess_errorHandling", BpmnNodeType.Activity.SubProcess(SubProcessKind.PLAIN)),
         FlowNodeDefinition("event_mailRejected", BpmnNodeType.Event(EventShape.START_EVENT, EventDefinitionType.MESSAGE),
-            properties = FlowNodeProperties.MessageEvent("Message_MailRejected", MessageDirection.CATCH),
+            properties = FlowNodeProperties.MessageEvent("Message_MailRejected", EventDirection.CATCH),
             parentId = "eventSubProcess_errorHandling",
             followingElements = listOf("serviceTask_analyzeError")),
         FlowNodeDefinition("serviceTask_analyzeError", BpmnNodeType.Activity.Task(TaskKind.SERVICE),
@@ -237,7 +238,7 @@ fun testSendNewsletterBpmnModel(
             parentId = "eventSubProcess_errorHandling",
             previousElements = listOf("gateway_canSendAgain")),
         FlowNodeDefinition("event_mailRejectedAgain", BpmnNodeType.Event(EventShape.INTERMEDIATE_CATCH_EVENT, EventDefinitionType.MESSAGE),
-            properties = FlowNodeProperties.MessageEvent("Message_MailRejectedAgain", MessageDirection.CATCH),
+            properties = FlowNodeProperties.MessageEvent("Message_MailRejectedAgain", EventDirection.CATCH),
             parentId = "eventSubProcess_errorHandling",
             previousElements = listOf("eventGateway_afterSendingAgain"), followingElements = listOf("escalationEndEvent_nofitySupportAfterRepeatedError")),
         FlowNodeDefinition("escalationEndEvent_nofitySupportAfterRepeatedError", BpmnNodeType.Event(EventShape.END_EVENT),

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/UncaughtSignalThrowRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/UncaughtSignalThrowRuleTest.kt
@@ -1,8 +1,8 @@
 package io.miragon.bpmn.domain.validation.rules
 
+import io.miragon.bpmn.domain.shared.EventDirection
 import io.miragon.bpmn.domain.shared.FlowNodeDefinition
 import io.miragon.bpmn.domain.shared.FlowNodeProperties
-import io.miragon.bpmn.domain.shared.EventDirection
 import io.miragon.bpmn.domain.shared.ProcessEngine
 import io.miragon.bpmn.domain.testBpmnModel
 import io.miragon.bpmn.domain.validation.model.CrossModelValidationContext
@@ -10,18 +10,18 @@ import io.miragon.bpmn.domain.validation.model.Severity
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class UncaughtMessageThrowRuleTest {
+class UncaughtSignalThrowRuleTest {
 
-    private val underTest = UncaughtMessageThrowRule()
+    private val underTest = UncaughtSignalThrowRule()
 
-    private fun throwNode(id: String, message: String) = FlowNodeDefinition(
+    private fun throwNode(id: String, signal: String) = FlowNodeDefinition(
         id = id,
-        properties = FlowNodeProperties.MessageEvent(message, EventDirection.THROW),
+        properties = FlowNodeProperties.SignalEvent(signal, EventDirection.THROW),
     )
 
-    private fun catchNode(id: String, message: String) = FlowNodeDefinition(
+    private fun catchNode(id: String, signal: String) = FlowNodeDefinition(
         id = id,
-        properties = FlowNodeProperties.MessageEvent(message, EventDirection.CATCH),
+        properties = FlowNodeProperties.SignalEvent(signal, EventDirection.CATCH),
     )
 
     private fun model(processId: String, vararg nodes: FlowNodeDefinition) =
@@ -31,27 +31,27 @@ class UncaughtMessageThrowRuleTest {
         underTest.validate(CrossModelValidationContext(models = models.toList(), engine = ProcessEngine.ZEEBE))
 
     @Test
-    fun `warns on a thrown message that is never caught in the fileset`() {
+    fun `warns on a thrown signal that is never caught in the fileset`() {
 
-        // given: a single model that throws a message no one catches
-        val thrower = model("orderPlacement", throwNode("throw1", "OrderShipped"))
+        // given: a single model that throws a signal no one subscribes to
+        val thrower = model("registration", throwNode("throw1", "RegistrationBlocked"))
 
         // when: the rule validates the model
         val violations = validate(thrower)
 
-        // then: a single WARN naming the uncaught message and its throwing element
+        // then: a single WARN naming the uncaught signal and its throwing element
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.WARN)
         assertThat(violations[0].elementId).isEqualTo("throw1")
-        assertThat(violations[0].processId).isEqualTo("orderPlacement")
-        assertThat(violations[0].message).contains("OrderShipped")
+        assertThat(violations[0].processId).isEqualTo("registration")
+        assertThat(violations[0].message).contains("RegistrationBlocked")
     }
 
     @Test
     fun `no warning when a catcher exists in the same model`() {
 
         // given: the throw and a matching catch live in one model
-        val model = model("orderPlacement", throwNode("throw1", "OrderShipped"), catchNode("catch1", "OrderShipped"))
+        val model = model("registration", throwNode("throw1", "RegistrationBlocked"), catchNode("catch1", "RegistrationBlocked"))
 
         // when: the rule validates the model
         val violations = validate(model)
@@ -63,9 +63,9 @@ class UncaughtMessageThrowRuleTest {
     @Test
     fun `no warning when the catcher lives in another loaded model`() {
 
-        // given: the message is thrown in one process and caught in another - the cross-model case
-        val thrower = model("orderPlacement", throwNode("throw1", "OrderShipped"))
-        val catcher = model("shipping", catchNode("catch1", "OrderShipped"))
+        // given: the signal is thrown in one process and caught in another - the cross-model case
+        val thrower = model("registration", throwNode("throw1", "RegistrationBlocked"))
+        val catcher = model("monitoring", catchNode("catch1", "RegistrationBlocked"))
 
         // when: the rule validates both models together
         val violations = validate(thrower, catcher)
@@ -75,18 +75,18 @@ class UncaughtMessageThrowRuleTest {
     }
 
     @Test
-    fun `warns only for the message whose catcher is missing`() {
+    fun `warns only for the signal whose catcher is missing`() {
 
-        // given: two thrown messages, only one of which is caught anywhere
-        val thrower = model("orderPlacement", throwNode("throw1", "OrderShipped"), throwNode("throw2", "OrderCancelled"))
-        val catcher = model("shipping", catchNode("catch1", "OrderShipped"))
+        // given: two thrown signals, only one of which is caught anywhere
+        val thrower = model("registration", throwNode("throw1", "RegistrationBlocked"), throwNode("throw2", "AccountLocked"))
+        val catcher = model("monitoring", catchNode("catch1", "RegistrationBlocked"))
 
         // when: the rule validates both models together
         val violations = validate(thrower, catcher)
 
-        // then: only the uncaught message is reported
+        // then: only the uncaught signal is reported
         assertThat(violations).hasSize(1)
         assertThat(violations[0].elementId).isEqualTo("throw2")
-        assertThat(violations[0].message).contains("OrderCancelled")
+        assertThat(violations[0].message).contains("AccountLocked")
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/UnpublishedSignalCatchRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/UnpublishedSignalCatchRuleTest.kt
@@ -1,0 +1,92 @@
+package io.miragon.bpmn.domain.validation.rules
+
+import io.miragon.bpmn.domain.shared.EventDirection
+import io.miragon.bpmn.domain.shared.FlowNodeDefinition
+import io.miragon.bpmn.domain.shared.FlowNodeProperties
+import io.miragon.bpmn.domain.shared.ProcessEngine
+import io.miragon.bpmn.domain.testBpmnModel
+import io.miragon.bpmn.domain.validation.model.CrossModelValidationContext
+import io.miragon.bpmn.domain.validation.model.Severity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class UnpublishedSignalCatchRuleTest {
+
+    private val underTest = UnpublishedSignalCatchRule()
+
+    private fun throwNode(id: String, signal: String) = FlowNodeDefinition(
+        id = id,
+        properties = FlowNodeProperties.SignalEvent(signal, EventDirection.THROW),
+    )
+
+    private fun catchNode(id: String, signal: String) = FlowNodeDefinition(
+        id = id,
+        properties = FlowNodeProperties.SignalEvent(signal, EventDirection.CATCH),
+    )
+
+    private fun model(processId: String, vararg nodes: FlowNodeDefinition) =
+        testBpmnModel(processId = processId, flowNodes = nodes.toList())
+
+    private fun validate(vararg models: io.miragon.bpmn.domain.BpmnModel) =
+        underTest.validate(CrossModelValidationContext(models = models.toList(), engine = ProcessEngine.ZEEBE))
+
+    @Test
+    fun `warns on a caught signal that is never thrown in the fileset`() {
+
+        // given: a single model that subscribes to a signal no one publishes
+        val subscriber = model("monitoring", catchNode("catch1", "RegistrationBlocked"))
+
+        // when: the rule validates the model
+        val violations = validate(subscriber)
+
+        // then: a single WARN naming the orphaned signal and its catching element
+        assertThat(violations).hasSize(1)
+        assertThat(violations[0].severity).isEqualTo(Severity.WARN)
+        assertThat(violations[0].elementId).isEqualTo("catch1")
+        assertThat(violations[0].processId).isEqualTo("monitoring")
+        assertThat(violations[0].message).contains("RegistrationBlocked")
+    }
+
+    @Test
+    fun `no warning when a thrower exists in the same model`() {
+
+        // given: the catch and a matching throw live in one model
+        val model = model("monitoring", catchNode("catch1", "RegistrationBlocked"), throwNode("throw1", "RegistrationBlocked"))
+
+        // when: the rule validates the model
+        val violations = validate(model)
+
+        // then: no violation is reported
+        assertThat(violations).isEmpty()
+    }
+
+    @Test
+    fun `no warning when the thrower lives in another loaded model`() {
+
+        // given: the signal is caught in one process and thrown in another - the cross-model case
+        val subscriber = model("monitoring", catchNode("catch1", "RegistrationBlocked"))
+        val publisher = model("registration", throwNode("throw1", "RegistrationBlocked"))
+
+        // when: the rule validates both models together
+        val violations = validate(subscriber, publisher)
+
+        // then: no violation is reported
+        assertThat(violations).isEmpty()
+    }
+
+    @Test
+    fun `warns only for the signal whose thrower is missing`() {
+
+        // given: two caught signals, only one of which is thrown anywhere
+        val subscriber = model("monitoring", catchNode("catch1", "RegistrationBlocked"), catchNode("catch2", "AccountLocked"))
+        val publisher = model("registration", throwNode("throw1", "RegistrationBlocked"))
+
+        // when: the rule validates both models together
+        val violations = validate(subscriber, publisher)
+
+        // then: only the orphaned signal is reported
+        assertThat(violations).hasSize(1)
+        assertThat(violations[0].elementId).isEqualTo("catch2")
+        assertThat(violations[0].message).contains("AccountLocked")
+    }
+}

--- a/bpmn-to-code-core/src/test/resources/json/NewsletterSubscriptionProcess.json
+++ b/bpmn-to-code-core/src/test/resources/json/NewsletterSubscriptionProcess.json
@@ -142,7 +142,12 @@
             "elementType": "SIGNAL_END_EVENT",
             "previousElements": [
                 "ErrorEvent_InvalidMail"
-            ]
+            ],
+            "properties": {
+                "type": "SignalEvent",
+                "signalName": "Signal_RegistrationNotPossible",
+                "signalDirection": "THROW"
+            }
         },
         {
             "id": "Timer_After3Days",

--- a/bpmn-to-code-testing/src/main/kotlin/io/miragon/bpmn/testing/BpmnRules.kt
+++ b/bpmn-to-code-testing/src/main/kotlin/io/miragon/bpmn/testing/BpmnRules.kt
@@ -16,6 +16,8 @@ import io.miragon.bpmn.domain.validation.rules.MissingTimerDefinitionRule
 import io.miragon.bpmn.domain.validation.rules.TimerCronSyntaxRule
 import io.miragon.bpmn.domain.validation.rules.TimerIso8601SyntaxRule
 import io.miragon.bpmn.domain.validation.rules.UncaughtMessageThrowRule
+import io.miragon.bpmn.domain.validation.rules.UncaughtSignalThrowRule
+import io.miragon.bpmn.domain.validation.rules.UnpublishedSignalCatchRule
 
 /**
  * Provides access to all built-in BPMN validation rules.
@@ -128,6 +130,25 @@ object BpmnRules {
      */
     @JvmField
     val UNCAUGHT_MESSAGE_THROW: CrossModelValidationRule = UncaughtMessageThrowRule()
+
+    /**
+     * Opt-in: warns when a signal is thrown (signal end / intermediate throw event) but no catching
+     * event subscribes to it anywhere in the loaded fileset. Cross-model — only meaningful when the
+     * whole related fileset is loaded together, so it is not part of [all]. Reported as WARN, since
+     * signals are broadcast and a subscriber outside the fileset is possible.
+     */
+    @JvmField
+    val UNCAUGHT_SIGNAL_THROW: CrossModelValidationRule = UncaughtSignalThrowRule()
+
+    /**
+     * Opt-in: warns when a signal is caught (signal start / intermediate catch / boundary event) but no
+     * throwing event publishes it anywhere in the loaded fileset — an orphaned subscriber, the mirror of
+     * [UNCAUGHT_SIGNAL_THROW]. Cross-model — only meaningful when the whole related fileset is loaded
+     * together, so it is not part of [all]. Reported as WARN, since signals are broadcast and a publisher
+     * outside the fileset is possible.
+     */
+    @JvmField
+    val UNPUBLISHED_SIGNAL_CATCH: CrossModelValidationRule = UnpublishedSignalCatchRule()
 
     /**
      * Returns all built-in BPMN validation rules that are enabled by default.

--- a/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/BpmnRulesTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/BpmnRulesTest.kt
@@ -57,6 +57,8 @@ class BpmnRulesTest {
         assertThat(BpmnRules.all().map { it.id }).doesNotContain(
             BpmnRules.CALL_ACTIVITY_TARGET_EXISTS.id,
             BpmnRules.UNCAUGHT_MESSAGE_THROW.id,
+            BpmnRules.UNCAUGHT_SIGNAL_THROW.id,
+            BpmnRules.UNPUBLISHED_SIGNAL_CATCH.id,
         )
     }
 
@@ -66,5 +68,7 @@ class BpmnRulesTest {
         assertThat(BpmnRules.TIMER_ISO8601_SYNTAX.id).isEqualTo("timer-iso8601-syntax")
         assertThat(BpmnRules.CALL_ACTIVITY_TARGET_EXISTS.id).isEqualTo("call-activity-target-exists")
         assertThat(BpmnRules.UNCAUGHT_MESSAGE_THROW.id).isEqualTo("uncaught-message-throw")
+        assertThat(BpmnRules.UNCAUGHT_SIGNAL_THROW.id).isEqualTo("uncaught-signal-throw")
+        assertThat(BpmnRules.UNPUBLISHED_SIGNAL_CATCH.id).isEqualTo("unpublished-signal-catch")
     }
 }

--- a/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/CrossModelRuleTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/CrossModelRuleTest.kt
@@ -59,4 +59,52 @@ class CrossModelRuleTest {
             .validate()
             .assertNoViolations()
     }
+
+    @Test
+    fun `warns when a thrown signal has no subscriber among the loaded models`() {
+        BpmnValidator
+            .fromClasspath("bpmn/signal-flow/registration-blocked.bpmn")
+            .engine(ProcessEngine.CAMUNDA_7)
+            .withRules(BpmnRules.UNCAUGHT_SIGNAL_THROW)
+            .validate()
+            .assertViolation(
+                ruleId = BpmnRules.UNCAUGHT_SIGNAL_THROW.id,
+                elementId = "EndEvent_RegistrationBlocked",
+                messageContains = "RegistrationBlocked",
+            )
+    }
+
+    @Test
+    fun `passes when the thrown signal is caught by another loaded model`() {
+        BpmnValidator
+            .fromClasspath("bpmn/signal-flow/")
+            .engine(ProcessEngine.CAMUNDA_7)
+            .withRules(BpmnRules.UNCAUGHT_SIGNAL_THROW)
+            .validate()
+            .assertNoViolations()
+    }
+
+    @Test
+    fun `warns when a caught signal is never thrown among the loaded models`() {
+        BpmnValidator
+            .fromClasspath("bpmn/signal-flow/registration-monitor.bpmn")
+            .engine(ProcessEngine.CAMUNDA_7)
+            .withRules(BpmnRules.UNPUBLISHED_SIGNAL_CATCH)
+            .validate()
+            .assertViolation(
+                ruleId = BpmnRules.UNPUBLISHED_SIGNAL_CATCH.id,
+                elementId = "StartEvent_RegistrationBlocked",
+                messageContains = "RegistrationBlocked",
+            )
+    }
+
+    @Test
+    fun `passes when the caught signal is thrown by another loaded model`() {
+        BpmnValidator
+            .fromClasspath("bpmn/signal-flow/")
+            .engine(ProcessEngine.CAMUNDA_7)
+            .withRules(BpmnRules.UNPUBLISHED_SIGNAL_CATCH)
+            .validate()
+            .assertNoViolations()
+    }
 }

--- a/bpmn-to-code-testing/src/test/resources/bpmn/signal-flow/registration-blocked.bpmn
+++ b/bpmn-to-code-testing/src/test/resources/bpmn/signal-flow/registration-blocked.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  id="Definitions_RegistrationBlocked"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:signal id="Signal_RegistrationBlocked" name="RegistrationBlocked" />
+  <bpmn:process id="registrationBlocked" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_RegistrationRejected" name="Registration rejected">
+      <bpmn:outgoing>Flow_ToBlocked</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_RegistrationBlocked" name="Registration blocked">
+      <bpmn:incoming>Flow_ToBlocked</bpmn:incoming>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_RegistrationBlocked" signalRef="Signal_RegistrationBlocked" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_ToBlocked" sourceRef="StartEvent_RegistrationRejected" targetRef="EndEvent_RegistrationBlocked" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="registrationBlocked">
+      <bpmndi:BPMNShape id="StartEvent_RegistrationRejected_di" bpmnElement="StartEvent_RegistrationRejected">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_RegistrationBlocked_di" bpmnElement="EndEvent_RegistrationBlocked">
+        <dc:Bounds x="292" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_ToBlocked_di" bpmnElement="Flow_ToBlocked">
+        <di:waypoint x="188" y="100" />
+        <di:waypoint x="292" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpmn-to-code-testing/src/test/resources/bpmn/signal-flow/registration-monitor.bpmn
+++ b/bpmn-to-code-testing/src/test/resources/bpmn/signal-flow/registration-monitor.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  id="Definitions_RegistrationMonitor"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:signal id="Signal_RegistrationBlocked" name="RegistrationBlocked" />
+  <bpmn:process id="registrationMonitor" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_RegistrationBlocked" name="Registration blocked">
+      <bpmn:outgoing>Flow_ToNotify</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_RegistrationBlockedCatch" signalRef="Signal_RegistrationBlocked" />
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_OperationsNotified" name="Operations notified">
+      <bpmn:incoming>Flow_ToNotify</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_ToNotify" sourceRef="StartEvent_RegistrationBlocked" targetRef="EndEvent_OperationsNotified" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="registrationMonitor">
+      <bpmndi:BPMNShape id="StartEvent_RegistrationBlocked_di" bpmnElement="StartEvent_RegistrationBlocked">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_OperationsNotified_di" bpmnElement="EndEvent_OperationsNotified">
+        <dc:Bounds x="292" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_ToNotify_di" bpmnElement="Flow_ToNotify">
+        <di:waypoint x="188" y="100" />
+        <di:waypoint x="292" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/docs/validate/testing.md
+++ b/docs/validate/testing.md
@@ -141,8 +141,10 @@ These rules are **not** part of `BpmnRules.all()` — they are off by default. E
 | Timer value is not valid ISO-8601 | `TIMER_ISO8601_SYNTAX` | ERROR | A timer value that is not valid ISO-8601 for its type (Date → date/time, Duration → duration, Cycle → repeating interval) |
 | Call activity target is missing | `CALL_ACTIVITY_TARGET_EXISTS` | ERROR | A call activity references a process that is not among the loaded models (a dangling call activity) |
 | Thrown message has no catcher | `UNCAUGHT_MESSAGE_THROW` | WARN | A message is thrown (message end / intermediate throw event) but no catching event exists among the loaded models |
+| Thrown signal has no subscriber | `UNCAUGHT_SIGNAL_THROW` | WARN | A signal is thrown (signal end / intermediate throw event) but no catching event subscribes to it among the loaded models |
+| Caught signal is never thrown | `UNPUBLISHED_SIGNAL_CATCH` | WARN | A signal is caught (signal start / intermediate catch / boundary event) but no throwing event publishes it among the loaded models |
 
-`CALL_ACTIVITY_TARGET_EXISTS` and `UNCAUGHT_MESSAGE_THROW` are [cross-model rules](#cross-process-multi-model-rules): they only hold when the **whole** related fileset is loaded together, which is exactly why they are opt-in rather than part of `all()` — see the tip on loading the whole set below. `UNCAUGHT_MESSAGE_THROW` reports as **WARN** rather than ERROR because a legitimate consumer may live outside the loaded fileset; a catcher is any message start / intermediate-catch / boundary event or receive task, in any loaded model.
+`CALL_ACTIVITY_TARGET_EXISTS`, `UNCAUGHT_MESSAGE_THROW`, and `UNCAUGHT_SIGNAL_THROW` are [cross-model rules](#cross-process-multi-model-rules): they only hold when the **whole** related fileset is loaded together, which is exactly why they are opt-in rather than part of `all()` — see the tip on loading the whole set below. `UNCAUGHT_MESSAGE_THROW` reports as **WARN** rather than ERROR because a legitimate consumer may live outside the loaded fileset; a catcher is any message start / intermediate-catch / boundary event or receive task, in any loaded model. `UNCAUGHT_SIGNAL_THROW` is likewise **WARN**: signals are broadcast, so a subscriber may live outside the loaded fileset; a subscriber is any signal start / intermediate-catch / boundary event, in any loaded model. `UNPUBLISHED_SIGNAL_CATCH` is the mirror of `UNCAUGHT_SIGNAL_THROW` — it flags an orphaned subscriber (a caught signal that no loaded model throws) and is **WARN** for the same reason: a publisher may live outside the loaded fileset.
 
 ```kotlin
 BpmnValidator
@@ -332,13 +334,14 @@ single-model rule reports an `ERROR`, validation stops before the merge and the 
 runs (post-merge rules like `COLLISION_DETECTION` do not short-circuit it).
 :::
 
-Message correlation across processes already ships built-in as the opt-in `UNCAUGHT_MESSAGE_THROW` rule
-(see [Optional Rules](#optional-rules-opt-in)) — it collects every thrown message name across all loaded
-models and warns when one has no catching event anywhere in the set.
+Message and signal correlation across processes already ship built-in as the opt-in
+`UNCAUGHT_MESSAGE_THROW` and `UNCAUGHT_SIGNAL_THROW` rules (see [Optional Rules](#optional-rules-opt-in))
+— each collects every thrown message/signal name across all loaded models and warns when one has no
+catching event anywhere in the set.
 
 Other cross-process checks you can write with the same building blocks: input-coverage ("does every
-caller pass the variables the called process reads?"), output-consumption, signal correlation
-across processes, and process-id uniqueness across the whole fileset.
+caller pass the variables the called process reads?"), output-consumption, and process-id uniqueness
+across the whole fileset.
 
 ::: tip SingleModelValidationContext
 `context.model` gives you the full `BpmnModel` — flow nodes, service tasks, call activities, messages, signals, errors, timers, and variables. `context.engine` tells you which engine was selected, so you can write engine-specific rules.


### PR DESCRIPTION
Closes #50.

## What

Two opt-in cross-model **WARN** rules for signals, mirroring the shipped `uncaught-message-throw`:

- **`UNCAUGHT_SIGNAL_THROW`** — a signal is thrown (signal end / intermediate throw event) but no catching event subscribes to it anywhere in the loaded fileset (the issue's request).
- **`UNPUBLISHED_SIGNAL_CATCH`** — the mirror: a signal is caught but no loaded model throws it (an orphaned subscriber).

Both are opt-in (not in `BpmnRules.all()`) and **WARN**, since signals are broadcast and a publisher/subscriber may live outside the loaded fileset.

## Why WARN / opt-in

Cross-model rules only hold when the whole related fileset is loaded together, and external signal endpoints are legitimate — so they can only warn, and are enabled explicitly via `withRules(...)`.

## Domain change

Couples the signal name + throw/catch role to the event node via a new `FlowNodeProperties.SignalEvent(name, direction)`, populated in each engine extractor (C7, Operaton, Zeebe). To avoid duplication, the shared `MessageDirection` enum is generalised into `EventDirection` and the event-shape→direction mapping is extracted into `EventDirectionUtils`, reused by both message and signal extraction.

## Tests & docs

- Core unit tests for both rules; extractor + JSON snapshot updates for the existing signal throw node.
- Integration tests via `bpmn/signal-flow/` fixtures (throwing model, catching model) covering both rules.
- `BpmnRulesTest` opt-in / id assertions.
- `docs/validate/testing.md` updated.

Note: the message equivalent of `UNPUBLISHED_SIGNAL_CATCH` was intentionally left out — a message catch with no in-fileset thrower is very commonly legitimate (external API correlation), so it would be too noisy.