### PR TITLE
docs: symlink AGENTS.md to CLAUDE.md and improve testing builder docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Tests are organized by layer:
 - Integration tests for adapters and extractors
 - Test resources include sample BPMN files and expected API outputs
 
-The project uses JUnit 5, AssertJ, and MockK for testing.
+The project uses JUnit 5, AssertJ, and MockK for testing. Use [`testBpmnModel()`](bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/TestBpmnModel.kt) or domain-specific builders like [`buildSubscribeNewsletterFlowNodes()`](bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/codegen/builder/NewsletterFlowNodes.kt) to programmatically construct test models instead of parsing BPMN files or hand-building domain objects.
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary
- Create AGENTS.md symlink to CLAUDE.md so non-Claude agents can access the same codebase guidance
- Add direct links to test builder functions (testBpmnModel, buildSubscribeNewsletterFlowNodes) in testing strategy section
- Clarify that builders help avoid both BPMN file parsing and manual domain object construction

## Test plan
- [ ] Verify symlink resolves correctly on clone
- [ ] Confirm links point to correct files