### PR TITLE
feat(validation): make integrity-critical rules non-disableable

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/service/BpmnValidationService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/service/BpmnValidationService.kt
@@ -29,10 +29,14 @@ class BpmnValidationService(
 
     private val allRules = builtInRules()
 
+    init {
+        warnOnDisabledMandatoryRules()
+    }
+
     fun collectViolations(models: List<ProcessModel>, engine: ProcessEngine, phase: ValidationPhase): List<ValidationViolation> {
         val activeRules = allRules
             .filter { it.phase == phase }
-            .filterNot { it.id in config.disabledRules }
+            .filterNot { it.id in config.disabledRules && !it.mandatory }
 
         return models.flatMap { model ->
             val ctx = SingleModelValidationContext(model, engine)
@@ -64,6 +68,19 @@ class BpmnValidationService(
         if (failingViolations.isNotEmpty()) {
             throw BpmnValidationException(failingViolations)
         }
+    }
+
+    /**
+     * Mandatory rules are integrity-critical: they stay active on every path and cannot be disabled
+     * via [ValidationConfig.disabledRules]. When a caller tries anyway, the attempt is surfaced as a
+     * warning rather than silently ignored — the rule is kept active regardless.
+     */
+    private fun warnOnDisabledMandatoryRules() {
+        allRules
+            .filter { it.mandatory && it.id in config.disabledRules }
+            .forEach { rule ->
+                logger.warn { "[BPMN VALIDATION] Rule '${rule.id}' is mandatory and cannot be disabled; keeping it active." }
+            }
     }
 
     companion object {

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/ValidationRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/ValidationRule.kt
@@ -11,4 +11,12 @@ import io.miragon.bpmn.domain.validation.model.Severity
 interface ValidationRule {
     val id: String
     val severity: Severity
+
+    /**
+     * Marks a rule as integrity-critical for code generation — it guarantees the generated code can
+     * emit a valid, unique constant name. Such rules cannot be turned off via `disabledRules` on the
+     * generation/validation path. The testing module generates no code and ignores this flag, so
+     * every rule stays disableable there.
+     */
+    val mandatory: Boolean get() = false
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/CollisionDetectionRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/CollisionDetectionRule.kt
@@ -18,6 +18,7 @@ class CollisionDetectionRule(
     override val id = "collision-detection"
     override val severity = Severity.ERROR
     override val phase = ValidationPhase.POST_MERGE
+    override val mandatory = true
 
     override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         val collisions = collisionDetectionService.findCollisions(context.model)

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingElementIdRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingElementIdRule.kt
@@ -15,6 +15,7 @@ class MissingElementIdRule : SingleModelValidationRule {
 
     override val id = "missing-element-id"
     override val severity = Severity.ERROR
+    override val mandatory = true
 
     override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         val model = context.model

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingProcessIdRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/rules/MissingProcessIdRule.kt
@@ -12,6 +12,7 @@ class MissingProcessIdRule : SingleModelValidationRule {
 
     override val id = "missing-process-id"
     override val severity = Severity.ERROR
+    override val mandatory = true
 
     override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
         if (context.model.processId.isBlank()) {

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/service/BpmnValidationServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/service/BpmnValidationServiceTest.kt
@@ -134,4 +134,47 @@ class BpmnValidationServiceTest {
         // then: the collision-detection rule fires
         assertThat(exception.violations).anyMatch { it.ruleId == "collision-detection" }
     }
+
+    @Test
+    fun `mandatory collision-detection rule stays active even when disabled`() {
+
+        // given: a service that tries to disable the mandatory collision-detection rule
+        val underTest = BpmnValidationService(
+            ValidationConfig(disabledRules = setOf("collision-detection"))
+        )
+        val model = testBpmnModel(
+            flowNodes = listOf(
+                FlowNodeDefinition(id = "endEvent_complete"),
+                FlowNodeDefinition(id = "endEvent-complete"),
+            )
+        )
+
+        // when: validating post-merge
+        val exception = assertThrows<BpmnValidationException> {
+            underTest.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.POST_MERGE)
+        }
+
+        // then: the collision-detection rule still fires despite being disabled
+        assertThat(exception.violations).anyMatch { it.ruleId == "collision-detection" }
+    }
+
+    @Test
+    fun `mandatory missing-element-id rule stays active even when disabled`() {
+
+        // given: a service that tries to disable the mandatory missing-element-id rule
+        val underTest = BpmnValidationService(
+            ValidationConfig(disabledRules = setOf("missing-element-id"))
+        )
+        val model = testBpmnModel(
+            flowNodes = listOf(FlowNodeDefinition(id = null))
+        )
+
+        // when: validating pre-merge
+        val exception = assertThrows<BpmnValidationException> {
+            underTest.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.PRE_MERGE)
+        }
+
+        // then: the missing-element-id rule still fires despite being disabled
+        assertThat(exception.violations).anyMatch { it.ruleId == "missing-element-id" }
+    }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MandatoryRuleFlagTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/MandatoryRuleFlagTest.kt
@@ -1,0 +1,24 @@
+package io.miragon.bpmn.domain.validation.rules
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies which rules are integrity-critical. Mandatory rules guarantee the generated code can emit
+ * a valid, unique constant name and therefore cannot be disabled via `disabledRules`.
+ */
+class MandatoryRuleFlagTest {
+
+    @Test
+    fun `integrity-critical rules are mandatory`() {
+        assertThat(CollisionDetectionRule().mandatory).isTrue()
+        assertThat(MissingElementIdRule().mandatory).isTrue()
+        assertThat(MissingProcessIdRule().mandatory).isTrue()
+    }
+
+    @Test
+    fun `optional rules are not mandatory`() {
+        assertThat(EmptyProcessRule().mandatory).isFalse()
+        assertThat(MissingServiceTaskImplementationRule().mandatory).isFalse()
+    }
+}

--- a/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/BpmnValidatorTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/miragon/bpmn/testing/BpmnValidatorTest.kt
@@ -1,6 +1,10 @@
 package io.miragon.bpmn.testing
 
 import io.miragon.bpmn.domain.shared.ProcessEngine
+import io.miragon.bpmn.domain.validation.SingleModelValidationRule
+import io.miragon.bpmn.domain.validation.model.Severity
+import io.miragon.bpmn.domain.validation.model.SingleModelValidationContext
+import io.miragon.bpmn.domain.validation.model.ValidationViolation
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -51,6 +55,17 @@ class BpmnValidatorTest {
     }
 
     @Test
+    fun `disableRules switches off a mandatory rule since no code is generated`() {
+        BpmnValidator
+            .fromClasspath("bpmn/valid-process.bpmn")
+            .engine(ProcessEngine.CAMUNDA_7)
+            .withRules(AlwaysFailingMandatoryRule())
+            .disableRules("always-failing-mandatory")
+            .validate()
+            .assertNoViolations("always-failing-mandatory")
+    }
+
+    @Test
     fun `missing engine throws clear error`() {
         assertThatThrownBy {
             BpmnValidator
@@ -83,5 +98,23 @@ class BpmnValidatorTest {
             .engine(ProcessEngine.CAMUNDA_7)
             .validate()
             .assertNoErrors()
+    }
+
+    private class AlwaysFailingMandatoryRule : SingleModelValidationRule {
+        override val id = "always-failing-mandatory"
+        override val severity = Severity.ERROR
+        override val mandatory = true
+
+        override fun validate(context: SingleModelValidationContext): List<ValidationViolation> {
+            return listOf(
+                ValidationViolation(
+                    ruleId = id,
+                    severity = severity,
+                    elementId = null,
+                    processId = context.model.processId,
+                    message = "always fails",
+                ),
+            )
+        }
     }
 }

--- a/docs/validate/index.md
+++ b/docs/validate/index.md
@@ -16,11 +16,13 @@ bpmn-to-code can validate your BPMN models against a set of built-in rules — i
 | `missing-signal-name` | ERROR | Signal event with no signal name |
 | `missing-timer-definition` | ERROR | Timer event with no timer type or value |
 | `missing-called-element` | ERROR | Call activity with no `calledElement` reference |
-| `missing-element-id` | ERROR | Flow node with no ID |
-| `missing-process-id` | ERROR | Process with no `id` attribute |
+| `missing-element-id` | ERROR | Flow node with no ID · **mandatory** |
+| `missing-process-id` | ERROR | Process with no `id` attribute · **mandatory** |
 | `empty-process` | ERROR | Process with no flow nodes |
-| `collision-detection` | ERROR | Two different element IDs that normalize to the same constant name (post-merge) |
+| `collision-detection` | ERROR | Two different element IDs that normalize to the same constant name (post-merge) · **mandatory** |
 | `engine-mismatch` | ERROR / WARN | Model's target engine (from its XML namespace) differs from the selected one |
+
+**Mandatory** rules are integrity-critical — they guarantee the generated code can emit a valid, unique constant name. Because they protect code generation, they stay active during both generation and build-time validation and **cannot be turned off** via `disabledRules`; listing one has no effect (a warning is logged). The [Testing Module](/validate/testing) generates no code, so it does not enforce this.
 
 ## Gradle
 
@@ -105,19 +107,19 @@ mvn bpmn-to-code:validate-bpmn
 
 ## Disabling Rules
 
-Pass rule IDs to `disabledRules` to skip specific checks:
+Pass rule IDs to `disabledRules` to skip specific checks. Mandatory rules (see the table above) cannot be disabled — listing one has no effect and logs a warning.
 
 ::: code-group
 
 ```kotlin [Gradle]
 tasks.named("validateBpmnModels", ValidateBpmnModelsTask::class) {
-    disabledRules = setOf("collision-detection", "empty-process")
+    disabledRules = setOf("missing-timer-definition", "empty-process")
 }
 ```
 
 ```xml [Maven]
 <disabledRules>
-    <disabledRule>collision-detection</disabledRule>
+    <disabledRule>missing-timer-definition</disabledRule>
     <disabledRule>empty-process</disabledRule>
 </disabledRules>
 ```

--- a/docs/validate/testing.md
+++ b/docs/validate/testing.md
@@ -82,6 +82,8 @@ BpmnValidator
     .assertNoViolations()
 ```
 
+Any rule can be disabled here, including integrity-critical ones like `collision-detection`. The testing module generates no code, so the mandatory-rule protection that applies to [build-time validation](/validate/) does not restrict test authoring.
+
 ## Treating Warnings as Failures
 
 ```kotlin


### PR DESCRIPTION
Validation rules could be turned off via `disabledRules` with no notion of criticality, so disabling a rule like `collision-detection` on the generation path could silently produce non-compiling generated code.

This adds a `mandatory` flag on `ValidationRule` for integrity-critical rules that guarantee the generated code can emit a valid, unique constant name (`collision-detection`, `missing-element-id`, `missing-process-id`). The flag is enforced per use-case:

- **Code generation / build-time validation** (core `BpmnValidationService`): mandatory rules stay active and cannot be removed via `disabledRules` — listing one has no effect and logs a warning.
- **Testing module** (`BpmnValidator`): generates no code, so it does not enforce the flag; every rule stays freely disableable for test authoring.

Non-breaking and additive — `ValidationConfig` and optional-rule behavior are unchanged. Covered by new tests and documented.

Closes #59
