### PR TITLE
docs: remove redundant mandatory-rule KDoc

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/ValidationRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/validation/ValidationRule.kt
@@ -11,12 +11,5 @@ import io.miragon.bpmn.domain.validation.model.Severity
 interface ValidationRule {
     val id: String
     val severity: Severity
-
-    /**
-     * Marks a rule as integrity-critical for code generation — it guarantees the generated code can
-     * emit a valid, unique constant name. Such rules cannot be turned off via `disabledRules` on the
-     * generation/validation path. The testing module generates no code and ignores this flag, so
-     * every rule stays disableable there.
-     */
     val mandatory: Boolean get() = false
 }


### PR DESCRIPTION
Removes the redundant KDoc on `ValidationRule.mandatory`. The enforcement behavior is already documented at the `warnOnDisabledMandatoryRules()` call site in `BpmnValidationService`, so the interface-level comment only duplicated it.

No behavior change.
