### PR TITLE
fix(validation): detect identifier-folding collisions in flow nodes

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/service/CollisionDetectionService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/service/CollisionDetectionService.kt
@@ -2,6 +2,7 @@ package io.miragon.bpmn.domain.service
 
 import io.miragon.bpmn.domain.ProcessModel
 import io.miragon.bpmn.domain.shared.VariableMapping
+import io.miragon.bpmn.domain.utils.StringUtils.toCamelCase
 import io.miragon.bpmn.domain.validation.model.CollisionDetail
 
 /**
@@ -26,16 +27,19 @@ class CollisionDetectionService {
         collisions.addAll(findCollisionsIn(modelId, model.errors, "Error"))
         collisions.addAll(findCollisionsIn(modelId, model.timers, "Timer"))
         collisions.addAll(findCollisionsIn(modelId, model.variables, "Variable"))
-        return collisions
+        collisions.addAll(findCollisionsIn(modelId, model.flowNodes, "FlowNode") { it.getRawName().toCamelCase() })
+        return collisions.distinctBy { Triple(it.processId, it.variableType, it.conflictingIds) }
     }
 
     private fun <T : VariableMapping<*>> findCollisionsIn(
         processId: String,
         items: List<T>,
         variableType: String,
+        nameSelector: (T) -> String = { it.getName() },
     ): List<CollisionDetail> {
         val distinctItems = items.filter { it.getRawName().isNotEmpty() }.distinctBy { it.getRawName() }
-        val itemsPerVariableName = distinctItems.groupBy { it.getName() }
+        val relevantItems = distinctItems.filter { nameSelector(it).isNotEmpty() }
+        val itemsPerVariableName = relevantItems.groupBy(nameSelector)
         val collisions = itemsPerVariableName.filterValues { it.size > 1 }
         return collisions.mapNotNull { (constantName, itemsWithSameName) ->
             val rawNames = itemsWithSameName.map { it.getRawName() }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/service/BpmnValidationServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/service/BpmnValidationServiceTest.kt
@@ -136,6 +136,27 @@ class BpmnValidationServiceTest {
     }
 
     @Test
+    fun `post-merge collision detection detects folding collisions`() {
+
+        // given: two flow nodes whose ids keep distinct constants but fold to the same
+        // PascalCase object name — previously emitted non-compiling generated code
+        val model = testBpmnModel(
+            flowNodes = listOf(
+                FlowNodeDefinition(id = "foo"),
+                FlowNodeDefinition(id = "-foo"),
+            )
+        )
+
+        // when: validating post-merge
+        val exception = assertThrows<BpmnValidationException> {
+            underTest.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.POST_MERGE)
+        }
+
+        // then: the collision-detection rule fires
+        assertThat(exception.violations).anyMatch { it.ruleId == "collision-detection" }
+    }
+
+    @Test
     fun `mandatory collision-detection rule stays active even when disabled`() {
 
         // given: a service that tries to disable the mandatory collision-detection rule

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/service/CollisionDetectionServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/service/CollisionDetectionServiceTest.kt
@@ -146,6 +146,70 @@ class CollisionDetectionServiceTest {
     }
 
     @Test
+    fun `findCollisions detects folding collision that UPPER_SNAKE misses`() {
+
+        // given: two flow nodes whose ids keep distinct constants (FOO, _FOO) but fold to the
+        // same PascalCase object name (Foo) used for Variables/CallActivities objects
+        val model = testBpmnModel(
+            processId = "TestProcess",
+            flowNodes = listOf(
+                FlowNodeDefinition(id = "foo"),
+                FlowNodeDefinition(id = "-foo"),
+            ),
+        )
+
+        // when: checking for collisions
+        val collisions = underTest.findCollisions(model)
+
+        // then: one collision is reported on the folded object-name basis
+        assertThat(collisions).hasSize(1)
+        assertThat(collisions[0].variableType).isEqualTo("FlowNode")
+        assertThat(collisions[0].constantName).isEqualTo("Foo")
+        assertThat(collisions[0].conflictingIds).containsExactlyInAnyOrder("-foo", "foo")
+    }
+
+    @Test
+    fun `findCollisions does not double-report a collision that surfaces on both bases`() {
+
+        // given: two flow nodes that collide in UPPER_SNAKE and in PascalCase folding
+        val model = testBpmnModel(
+            processId = "TestProcess",
+            flowNodes = listOf(
+                FlowNodeDefinition(id = "endEvent_complete"),
+                FlowNodeDefinition(id = "endEvent-complete"),
+            ),
+        )
+
+        // when: checking for collisions
+        val collisions = underTest.findCollisions(model)
+
+        // then: exactly one collision, keeping the UPPER_SNAKE constant name
+        assertThat(collisions).hasSize(1)
+        assertThat(collisions[0].constantName).isEqualTo("END_EVENT_COMPLETE")
+    }
+
+    @Test
+    fun `findCollisions detects UPPER_SNAKE collision that folding misses`() {
+
+        // given: two flow nodes that share a constant (FOO_BAR) but keep distinct PascalCase names
+        val model = testBpmnModel(
+            processId = "TestProcess",
+            flowNodes = listOf(
+                FlowNodeDefinition(id = "fooBar"),
+                FlowNodeDefinition(id = "fooBAR"),
+            ),
+        )
+
+        // when: checking for collisions
+        val collisions = underTest.findCollisions(model)
+
+        // then: still reported once on the UPPER_SNAKE basis
+        assertThat(collisions).hasSize(1)
+        assertThat(collisions[0].constantName).isEqualTo("FOO_BAR")
+        assertThat(collisions[0].conflictingIds).containsExactlyInAnyOrder("fooBAR", "fooBar")
+    }
+
+    @Test
     fun `findCollisions detects collisions in Messages`() {
 
         // given: two messages that normalize to the same constant

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/CollisionDetectionRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/validation/rules/CollisionDetectionRuleTest.kt
@@ -39,6 +39,27 @@ class CollisionDetectionRuleTest {
     }
 
     @Test
+    fun `reports collision when different IDs fold to the same object name`() {
+
+        // given: two flow nodes whose ids keep distinct constants but fold to the same
+        // PascalCase object name (previously emitted two non-compiling `object Foo`)
+        val model = testBpmnModel(
+            flowNodes = listOf(
+                FlowNodeDefinition(id = "foo"),
+                FlowNodeDefinition(id = "-foo"),
+            )
+        )
+
+        // when: validating
+        val violations = underTest.validate(SingleModelValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+
+        // then: one error violation referencing conflicting IDs
+        assertThat(violations).hasSize(1)
+        assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
+        assertThat(violations[0].message).contains("conflicting IDs")
+    }
+
+    @Test
     fun `no violations when no collisions`() {
 
         // given: two flow nodes with distinct constant names

--- a/docs/contributing/adr/011-variable-name-collision-detection.md
+++ b/docs/contributing/adr/011-variable-name-collision-detection.md
@@ -25,7 +25,14 @@ Implement comprehensive collision detection that:
 ### Implementation
 
 - Created `CollisionDetectionService` as a dedicated domain service following hexagonal architecture to detect collisions and throw errors
-  
+
+### Identifier-folding basis (flow nodes)
+Flow nodes additionally generate **PascalCase** object names (`Variables`, `CallActivities`) via `StringUtils.toCamelCase()`, which folds away empty segments from leading/trailing/collapsed separators. Ids such as `foo` and `-foo` keep distinct `UPPER_SNAKE` constants (`FOO` / `_FOO`) but fold to the same object name `Foo`, which would emit two `object Foo` and fail to compile. Flow-node collision detection therefore checks **both** bases:
+- the `UPPER_SNAKE` constant basis (`Elements`), and
+- the PascalCase object-name basis (`getRawName().toCamelCase()`).
+
+Neither basis subsumes the other (`fooBar` / `fooBAR` collide only in `UPPER_SNAKE`; `foo` / `-foo` only in folding), so both are needed. Collisions surfacing on both bases are de-duplicated and reported once, preferring the `UPPER_SNAKE` name. Call-activity ids are a subset of flow-node ids, so a single flow-node check covers `CallActivities` objects too.
+
 ## Consequences
 
 ### Positive


### PR DESCRIPTION
## Why

`collision-detection` is mandatory (#59/#60) yet only guarded the `UPPER_SNAKE` constant basis. The `CallActivities` and `Variables` sections derive PascalCase object names via `getRawName().toCamelCase()`, which folds away empty segments — so ids like `foo` and `-foo` keep distinct constants (`FOO`/`_FOO`) but fold to the same object name `Foo`, emitting two `object Foo` and producing non-compiling generated code that slipped past validation.

## What

- Add a PascalCase object-name collision check over flow nodes, alongside the existing `UPPER_SNAKE` check, with de-duplication when a collision surfaces on both bases (keeping the `UPPER_SNAKE` name).
- Keep both bases because neither subsumes the other (`fooBar`/`fooBAR` collide only in `UPPER_SNAKE`; `foo`/`-foo` only in folding); a single flow-node check also covers `CallActivities`, whose ids are a subset of flow-node ids.
- Add tests at the service, rule, and validation-service levels; document the folding basis in ADR 011.

## Verification

`./gradlew :bpmn-to-code-core:test` → all new and existing tests green.

Closes #62
