### PR TITLE
docs(contributing): add optional Graphify codebase-exploration section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ docs/.vitepress/cache
 .gstack/
 sandbox/
 detekt-baseline.xml
+
+# Graphify outputs
+graphify-out/

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -35,3 +35,23 @@ This installs a `pre-push` hook that runs `:bpmn-to-code-core:jacocoTestCoverage
 ```bash
 git push --no-verify  # bypasses lefthook; CI still enforces
 ```
+
+## Exploring the codebase (optional)
+
+The core follows a hexagonal architecture across several modules
+(`domain` → `application` → `adapter`). To navigate the relationships
+instead of grepping, some contributors use
+[Graphify](https://github.com/Graphify-Labs/graphify), which builds a
+local knowledge graph from the source (Kotlin included, AST-only, no API
+key required):
+
+```bash
+uv tool install graphifyy   # or: pipx install graphifyy
+graphify extract . --code-only   # local, ~5s, writes graphify-out/
+graphify god-nodes               # most-connected architectural hubs
+graphify affected "SomeType"     # what a change would impact
+```
+
+This is purely an optional exploration aid — it is **not** a build or
+contribution requirement, and its output (`graphify-out/`) is
+git-ignored.


### PR DESCRIPTION
## What

Adds an **optional** "Exploring the codebase" section to the contributing docs, pointing to [Graphify](https://github.com/Graphify-Labs/graphify) as a local knowledge-graph aid for navigating the hexagonal architecture, and git-ignores its `graphify-out/` output.

## Why

New contributors face a multi-module hexagonal codebase. A graph-based navigation aid (`god-nodes`, `affected`) lowers the barrier to orienting in the domain/application/adapter layers — without grepping.

## Notes

- Framed strictly as **optional**: not a build or contribution requirement, no API key needed (AST-only, `--code-only`).
- Not added to Prerequisites — it is not a build dependency.
- Only repo changes: `.gitignore` (+`graphify-out/`) and the docs page.