### PR TITLE
docs(ci): pin GitHub Actions to commit SHAs in verify-in-ci example

### DIFF
--- a/docs/guide/verify-in-ci.md
+++ b/docs/guide/verify-in-ci.md
@@ -30,16 +30,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
       - name: Regenerate the Process API
         run: ./gradlew generateBpmnModelApi


### PR DESCRIPTION
The example workflow in `docs/guide/verify-in-ci.md` used mutable version tags (`@v6`, `@v5`), while the tip directly below it advises pinning to commit SHAs for supply-chain safety. This fixes the inconsistency by replacing the tags with their corresponding commit SHAs (with the version tag kept as a comment).