### PR TITLE
feat(ci): publish SNAPSHOT versions to Maven Central Snapshots

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,62 @@
+name: Publish Snapshot to Maven Central Snapshots (io.miragon)
+
+on:
+  # Snapshots are published on demand only - not on every push to main.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Snapshot version to publish (must end with -SNAPSHOT, e.g. 5.1.0-SNAPSHOT)'
+        required: true
+        type: string
+
+# Snapshots are mutable - cancel a superseded run so the latest dispatch wins.
+concurrency:
+  group: publish-snapshot
+  cancel-in-progress: true
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    env:
+      # Same Central Portal token used by the release publish - the snapshot repo shares auth.
+      ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MIRAGON_SONATYPE_USERNAME }}
+      ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MIRAGON_SONATYPE_PASSWORD }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+
+      - name: Validate snapshot version
+        id: version
+        run: |
+          version="${{ inputs.version }}"
+          echo "$version" | grep -qE -- '-SNAPSHOT$' || { echo "::error::version must end with -SNAPSHOT"; exit 1; }
+          echo "snapshot=${version}" >> "$GITHUB_OUTPUT"
+          echo "Publishing snapshot version ${version}"
+
+      - name: Build & Test
+        run: ./gradlew build --warning-mode all
+
+      # Central Snapshots has no close/release step, so snapshots use `publishToMavenCentral`
+      # (upload only) - vanniktech auto-routes -SNAPSHOT versions to the snapshots repo.
+      # The three io.miragon library modules publish before the Gradle plugin, whose POM
+      # references bpmn-to-code-runtime.
+      - name: Publish snapshot to Maven Central Snapshots
+        run: >-
+          ./gradlew --no-configuration-cache
+          -PprojectVersion=${{ steps.version.outputs.snapshot }}
+          :bpmn-to-code-runtime:publishToMavenCentral
+          :bpmn-to-code-maven:publishToMavenCentral
+          :bpmn-to-code-testing:publishToMavenCentral
+          :bpmn-to-code-gradle:publishAllPublicationsToCentralSnapshotsRepository

--- a/bpmn-to-code-gradle/build.gradle.kts
+++ b/bpmn-to-code-gradle/build.gradle.kts
@@ -69,6 +69,8 @@ tasks.named<Test>("test") {
     systemProperty("kotlinVersion", libs.versions.kotlin.get())
 }
 
+val isSnapshot = version.toString().endsWith("-SNAPSHOT")
+
 publishing {
     publications {
         create<MavenPublication>("pluginMaven") {
@@ -78,6 +80,20 @@ publishing {
     }
     repositories {
         mavenLocal()
+        // The Gradle Plugin Portal cannot host SNAPSHOTs, so snapshot builds of the plugin
+        // (including its auto-generated plugin-marker publication) are published to Central
+        // Snapshots instead. Guarded so release versions never land here - the Portal stays
+        // the release channel.
+        if (isSnapshot) {
+            maven {
+                name = "centralSnapshots"
+                url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+                credentials {
+                    username = providers.gradleProperty("mavenCentralUsername").orNull
+                    password = providers.gradleProperty("mavenCentralPassword").orNull
+                }
+            }
+        }
     }
 }
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -117,6 +117,7 @@ export default defineConfig({
           { text: 'AI Skills Architecture', link: '/contributing/ai-skills' },
           { text: 'Docker Deployment', link: '/contributing/docker-hub-deployment' },
           { text: 'Best Practices', link: '/contributing/best-practices' },
+          { text: 'Publishing Snapshots', link: '/contributing/publishing-snapshots' },
           { text: 'Architecture Decisions', link: '/contributing/adr/' },
         ],
       },

--- a/docs/contributing/publishing-snapshots.md
+++ b/docs/contributing/publishing-snapshots.md
@@ -1,0 +1,124 @@
+# Publishing & Consuming Snapshots
+
+On demand, the current state of `main` can be published as a `-SNAPSHOT` build to the
+[Maven Central Snapshots](https://central.sonatype.com/repository/maven-snapshots/) repository. This
+lets you try unreleased changes in a real project without waiting for a release — no local
+`publishToMavenLocal` needed.
+
+Snapshots are **mutable**: a given `-SNAPSHOT` version is overwritten on each publish, so it always
+reflects the state of `main` at the time it was last published.
+
+## For maintainers
+
+Publishing is handled by the [`publish-snapshot.yml`](https://github.com/Miragon/bpmn-to-code/blob/main/.github/workflows/publish-snapshot.yml)
+workflow:
+
+- **Runs on demand only** (`workflow_dispatch`) — never automatically on push:
+  ```bash
+  gh workflow run publish-snapshot.yml -f version=5.1.0-SNAPSHOT
+  ```
+- **Version** is a required input and must end with `-SNAPSHOT` (the run fails otherwise). Use the
+  current `projectVersion` from `gradle.properties` with a `-SNAPSHOT` suffix. It is not gated behind
+  the release approval environment.
+- **Modules published:** `bpmn-to-code-runtime`, `bpmn-to-code-maven`, `bpmn-to-code-testing` (via
+  the Central Portal, using `publishToMavenCentral` — upload only, no close/release step), plus the
+  Gradle plugin `bpmn-to-code-gradle`.
+
+Because the **Gradle Plugin Portal cannot host SNAPSHOTs**, the Gradle plugin (and its plugin-marker
+artifact) is published to Central Snapshots instead. This path is guarded by an `isSnapshot` check in
+`bpmn-to-code-gradle/build.gradle.kts`, so release versions never land there — the Portal stays the
+release channel.
+
+> **Version-ordering note:** right after a release, `projectVersion` equals the last *released*
+> version (e.g. `5.1.0`), so the snapshot is `5.1.0-SNAPSHOT`, which Maven orders *below* `5.1.0`.
+> That is expected for a rolling "latest `main`" channel.
+
+## Consuming a snapshot — Gradle
+
+Add the snapshot repository to `pluginManagement` in your `settings.gradle.kts`, alongside the
+Plugin Portal, then apply the plugin at a `-SNAPSHOT` version. Gradle resolves it via the
+plugin-marker artifact published to Central Snapshots — the Portal itself never hosts snapshots.
+
+::: code-group
+
+```kotlin [settings.gradle.kts]
+pluginManagement {
+    repositories {
+        maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
+        gradlePluginPortal()
+    }
+}
+```
+
+```groovy [settings.gradle]
+pluginManagement {
+    repositories {
+        maven { url = 'https://central.sonatype.com/repository/maven-snapshots/' }
+        gradlePluginPortal()
+    }
+}
+```
+
+:::
+
+::: code-group
+
+```kotlin [build.gradle.kts]
+plugins {
+    id("io.miragon.bpmn-to-code-gradle") version "5.1.0-SNAPSHOT"
+}
+```
+
+```groovy [build.gradle]
+plugins {
+    id 'io.miragon.bpmn-to-code-gradle' version '5.1.0-SNAPSHOT'
+}
+```
+
+:::
+
+Use the current `projectVersion` from `main` with a `-SNAPSHOT` suffix. To always pull the freshest
+build, tell Gradle not to cache changing modules:
+
+```kotlin
+configurations.all {
+    resolutionStrategy.cacheChangingModulesFor(0, "seconds")
+}
+```
+
+## Consuming a snapshot — Maven
+
+Declare the snapshot repository for both plugins and dependencies, then reference the plugin (and the
+`bpmn-to-code-runtime` dependency) at a `-SNAPSHOT` version.
+
+```xml
+<pluginRepositories>
+    <pluginRepository>
+        <id>central-snapshots</id>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        <releases><enabled>false</enabled></releases>
+        <snapshots><enabled>true</enabled></snapshots>
+    </pluginRepository>
+</pluginRepositories>
+
+<repositories>
+    <repository>
+        <id>central-snapshots</id>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        <releases><enabled>false</enabled></releases>
+        <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+</repositories>
+```
+
+```xml
+<plugin>
+    <groupId>io.miragon</groupId>
+    <artifactId>bpmn-to-code-maven</artifactId>
+    <version>5.1.0-SNAPSHOT</version>
+    <!-- executions / configuration as in the Maven Setup guide -->
+</plugin>
+```
+
+See the [Maven Setup](/getting-started/maven) and [Gradle Setup](/getting-started/gradle) guides for
+the full plugin configuration.


### PR DESCRIPTION
## Summary

Adds an on-demand channel to publish the `io.miragon` artifacts as `-SNAPSHOT` builds to [Maven Central Snapshots](https://central.sonatype.com/repository/maven-snapshots/), so downstream projects and CI can consume unreleased changes without waiting for a release. Previously the only option was machine-local `publishToMavenLocal`.

Closes #69

## Changes

- **New workflow** `.github/workflows/publish-snapshot.yml` — `workflow_dispatch` only (no auto-publish on push). Takes a **required** `version` input that must end with `-SNAPSHOT` (fails otherwise), then publishes `bpmn-to-code-runtime`, `-maven`, `-testing` via `publishToMavenCentral` (upload only) plus the Gradle plugin. Reuses the existing `MIRAGON_SONATYPE_*` token; no GPG signing (Central Snapshots doesn't require it).
- **Gradle plugin** (`bpmn-to-code-gradle/build.gradle.kts`) — adds an `isSnapshot`-guarded `centralSnapshots` Maven repository. Since the Plugin Portal cannot host SNAPSHOTs, the plugin + its auto-generated plugin-marker go to Central Snapshots instead. The guard keeps release versions off Central — the Portal stays the release channel.
- **Docs** — new `docs/contributing/publishing-snapshots.md` (maintainer flow + Gradle/Maven consumer setup) wired into the Contributing sidebar.

## Verification

- Guard: `publishAllPublicationsToCentralSnapshotsRepository` exists with a `-SNAPSHOT` version, **absent** for a release version.
- Local end-to-end publish put all four modules into `~/.m2` as `5.1.0-SNAPSHOT`, including the marker `io.miragon.bpmn-to-code-gradle.gradle.plugin` (correctly referencing `io.miragon:bpmn-to-code-gradle`).
- Workflow YAML validated.

## Note

Version scheme is `<projectVersion>-SNAPSHOT`, so right after a release the snapshot (e.g. `5.1.0-SNAPSHOT`) sorts *below* the release `5.1.0` in Maven ordering — expected for a rolling "latest `main`" channel, documented in the page.