### PR TITLE
fix(maven): add missing Javadoc to BpmnJsonMojo constructor

### DIFF
--- a/bpmn-to-code-maven/src/main/java/io/miragon/bpmn/adapter/BpmnJsonMojo.java
+++ b/bpmn-to-code-maven/src/main/java/io/miragon/bpmn/adapter/BpmnJsonMojo.java
@@ -30,6 +30,9 @@ public class BpmnJsonMojo extends AbstractMojo {
 	@Parameter(property = "processEngine")
 	private String processEngine;
 
+	/**
+	 * Default constructor for maven purposes
+	 */
 	@SuppressWarnings("unused")
 	public BpmnJsonMojo() {
 	}


### PR DESCRIPTION
Adds the missing Javadoc comment to the `BpmnJsonMojo` no-arg constructor, which caused a Javadoc warning during Maven deployment. The other two Mojos (`BpmnModelMojo`, `BpmnValidateMojo`) already had this comment — this brings `BpmnJsonMojo` in line with them.