### PR TITLE
fix(codegen): generate process api deterministically

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/filesystem/BpmnFileLoader.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/adapter/outbound/filesystem/BpmnFileLoader.kt
@@ -25,6 +25,7 @@ class BpmnFileLoader : LoadBpmnFilesPort {
             .filter { Files.isRegularFile(it) }
             .filter { matcher.matches(searchDir.relativize(it)) }
             .toList()
+            .sortedBy { relativeSortKey(searchDir, it) }
 
         logger.info { "Found ${files.size} files matching pattern $pattern in directory $searchDir" }
 
@@ -34,6 +35,20 @@ class BpmnFileLoader : LoadBpmnFilesPort {
                 content = file.readBytes(),
             )
         }
+    }
+
+    /**
+     * Builds a deterministic sort key from a file's path relative to [searchDir].
+     *
+     * `Files.walk` returns entries in filesystem-dependent order (APFS vs ext4/overlayfs differ),
+     * which would leak into the generated code. We sort by the **relative path** rather than the
+     * file name because variant files legitimately share a file name across directories
+     * (e.g. `default/qualitaetssicherung.bpmn`, `karlsruhe/qualitaetssicherung.bpmn`), so file-name
+     * sorting is not a total order. Segments are joined with `/` so the key is identical across
+     * operating systems, and plain [String] ordering keeps it locale-independent.
+     */
+    private fun relativeSortKey(searchDir: Path, file: Path): String {
+        return searchDir.relativize(file).joinToString("/") { it.toString() }
     }
 
     private fun createMatcher(pattern: String): PathMatcher {

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/service/ModelMergerService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/service/ModelMergerService.kt
@@ -45,9 +45,6 @@ class ModelMergerService {
             "Multiple BPMN files share process ID '$processId' but not all define a variantName. " +
                 "Add a variantName extension property to each process."
         }
-        // Sort variants by name so generation is a deterministic function of the inputs, independent
-        // of the order in which files happened to be read from the filesystem. This also fixes the
-        // base-node selection in [mergeFlowNodes], which takes attributes from the first model.
         val sortedModels = models.sortedBy { requireNotNull(it.variantName) }
         return MergedBpmnModel(
             processId = processId,

--- a/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/service/ModelMergerService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/miragon/bpmn/domain/service/ModelMergerService.kt
@@ -16,13 +16,15 @@ class ModelMergerService {
      */
     fun mergeModels(models: List<BpmnModel>): List<ProcessModel> {
         val modelsPerProcess = models.groupBy { it.processId }
-        return modelsPerProcess.map { (processId, modelList) ->
-            if (modelList.size == 1) {
-                deduplicateSingleModel(modelList.first()).sortContent()
-            } else {
-                mergeModelsWithSameProcessId(processId, modelList).sortContent()
+        return modelsPerProcess.entries
+            .sortedBy { it.key }
+            .map { (processId, modelList) ->
+                if (modelList.size == 1) {
+                    deduplicateSingleModel(modelList.first()).sortContent()
+                } else {
+                    mergeModelsWithSameProcessId(processId, modelList).sortContent()
+                }
             }
-        }
     }
 
     private fun deduplicateSingleModel(model: BpmnModel): BpmnModel {
@@ -43,15 +45,19 @@ class ModelMergerService {
             "Multiple BPMN files share process ID '$processId' but not all define a variantName. " +
                 "Add a variantName extension property to each process."
         }
+        // Sort variants by name so generation is a deterministic function of the inputs, independent
+        // of the order in which files happened to be read from the filesystem. This also fixes the
+        // base-node selection in [mergeFlowNodes], which takes attributes from the first model.
+        val sortedModels = models.sortedBy { requireNotNull(it.variantName) }
         return MergedBpmnModel(
             processId = processId,
-            flowNodes = mergeFlowNodes(models),
-            messages = mergeDistinctBy(models) { it.messages },
-            signals = mergeDistinctBy(models) { it.signals },
-            errors = mergeDistinctBy(models) { it.errors },
-            escalations = mergeDistinctBy(models) { it.escalations },
-            compensations = mergeDistinctBy(models) { it.compensations },
-            variants = models.map { model ->
+            flowNodes = mergeFlowNodes(sortedModels),
+            messages = mergeDistinctBy(sortedModels) { it.messages },
+            signals = mergeDistinctBy(sortedModels) { it.signals },
+            errors = mergeDistinctBy(sortedModels) { it.errors },
+            escalations = mergeDistinctBy(sortedModels) { it.escalations },
+            compensations = mergeDistinctBy(sortedModels) { it.compensations },
+            variants = sortedModels.map { model ->
                 VariantData(
                     variantName = requireNotNull(model.variantName),
                     sequenceFlows = model.sequenceFlows,
@@ -65,6 +71,11 @@ class ModelMergerService {
      * Merges flow nodes across models by id, unioning additive list fields like `variables`
      * and `attachedElements` so that variant-specific extension data (e.g. additionalInputVariables)
      * is preserved instead of being dropped by simple deduplication.
+     *
+     * The merged node's base attributes (`name`, `previousElements`, `followingElements`, etc.) come
+     * from the first model in the given order. Callers pass models pre-sorted by `variantName`, so
+     * the base is a deterministic function of the inputs rather than of filesystem read order.
+     * `attachedElements` is sorted so the union is order-independent regardless of input.
      */
     private fun mergeFlowNodes(models: List<BpmnModel>): List<FlowNodeDefinition> {
         return models.flatMap { it.flowNodes }
@@ -73,7 +84,7 @@ class ModelMergerService {
             .map { (_, duplicates) ->
                 duplicates.first().copy(
                     variables = duplicates.flatMap { it.variables }.distinct(),
-                    attachedElements = duplicates.flatMap { it.attachedElements }.distinct(),
+                    attachedElements = duplicates.flatMap { it.attachedElements }.distinct().sorted(),
                 )
             }
     }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/filesystem/BpmnFileLoaderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/filesystem/BpmnFileLoaderTest.kt
@@ -135,4 +135,29 @@ class BpmnFileLoaderTest {
         assertThat(result).hasSize(1)
         assertThat(result[0].fileName).isEqualTo("target.bpmn")
     }
+
+    @Test
+    fun `loadFrom returns files ordered by relative path independent of filesystem order`(@TempDir tempDir: Path) {
+
+        // given: variant files that share a file name across sibling directories, plus siblings whose
+        // relative-path order differs from their file-name order
+        val folders = listOf("waghaeusel", "default", "kronstorf", "karlsruhe")
+        folders.forEach { folder ->
+            val dir = Files.createDirectory(tempDir.resolve(folder))
+            // content encodes the relative path so we can identify each resource regardless of file name
+            Files.write(dir.resolve("qualitaetssicherung.bpmn"), "$folder/qualitaetssicherung.bpmn".toByteArray())
+        }
+
+        // when: we load all of them
+        val result = underTest.loadFrom(tempDir.toString(), "**/*.bpmn")
+
+        // then: they come back sorted by their relative path (readdir order cannot be forced, so we
+        // assert the invariant, not a specific shuffle)
+        assertThat(result.map { String(it.content) }).containsExactly(
+            "default/qualitaetssicherung.bpmn",
+            "karlsruhe/qualitaetssicherung.bpmn",
+            "kronstorf/qualitaetssicherung.bpmn",
+            "waghaeusel/qualitaetssicherung.bpmn",
+        )
+    }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/filesystem/BpmnFileLoaderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/filesystem/BpmnFileLoaderTest.kt
@@ -141,11 +141,10 @@ class BpmnFileLoaderTest {
 
         // given: variant files that share a file name across sibling directories, plus siblings whose
         // relative-path order differs from their file-name order
-        val folders = listOf("waghaeusel", "default", "kronstorf", "karlsruhe")
+        val folders = listOf("staging", "dev", "test", "prod")
         folders.forEach { folder ->
             val dir = Files.createDirectory(tempDir.resolve(folder))
-            // content encodes the relative path so we can identify each resource regardless of file name
-            Files.write(dir.resolve("qualitaetssicherung.bpmn"), "$folder/qualitaetssicherung.bpmn".toByteArray())
+            Files.write(dir.resolve("order-process.bpmn"), "$folder/order-process.bpmn".toByteArray())
         }
 
         // when: we load all of them
@@ -154,10 +153,10 @@ class BpmnFileLoaderTest {
         // then: they come back sorted by their relative path (readdir order cannot be forced, so we
         // assert the invariant, not a specific shuffle)
         assertThat(result.map { String(it.content) }).containsExactly(
-            "default/qualitaetssicherung.bpmn",
-            "karlsruhe/qualitaetssicherung.bpmn",
-            "kronstorf/qualitaetssicherung.bpmn",
-            "waghaeusel/qualitaetssicherung.bpmn",
+            "dev/order-process.bpmn",
+            "prod/order-process.bpmn",
+            "staging/order-process.bpmn",
+            "test/order-process.bpmn",
         )
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/application/service/GenerateProcessApiDeterministicOrderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/application/service/GenerateProcessApiDeterministicOrderTest.kt
@@ -1,0 +1,81 @@
+package io.miragon.bpmn.application.service
+
+import io.miragon.bpmn.adapter.outbound.codegen.CodeGenerationAdapter
+import io.miragon.bpmn.application.port.outbound.ExtractBpmnPort
+import io.miragon.bpmn.domain.BpmnModel
+import io.miragon.bpmn.domain.BpmnResource
+import io.miragon.bpmn.application.port.inbound.GenerateProcessApiInMemoryUseCase
+import io.miragon.bpmn.application.port.inbound.GenerateProcessApiInMemoryUseCase.BpmnInput
+import io.miragon.bpmn.domain.GeneratedApiFile
+import io.miragon.bpmn.domain.shared.OutputLanguage
+import io.miragon.bpmn.domain.shared.ProcessEngine
+import io.miragon.bpmn.domain.testSendNewsletterBpmnModel
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Guards the property the CI drift-check relies on: generated code is a deterministic function of the
+ * `.bpmn` inputs, independent of the order in which the filesystem hands them to us. The loader test
+ * covers input ordering; this one covers the merger, feeding the same multi-variant model set through
+ * the service in several fixed (non-random) input orders and asserting byte-identical output.
+ */
+class GenerateProcessApiDeterministicOrderTest {
+
+    private val bpmnService = mockk<ExtractBpmnPort>()
+    private val underTest = GenerateProcessApiInMemoryService(
+        codeGenerator = CodeGenerationAdapter(),
+        bpmnService = bpmnService,
+    )
+
+    // Three variants of one process. Same shape, distinct variant names + a distinct node label so the
+    // emitted variant blocks and the merged base node differ — a reorder would change bytes if unfixed.
+    private val variantNames = listOf("waghaeusel", "default", "kronstorf")
+
+    private val modelsByName: Map<String, BpmnModel> = variantNames.associateWith { name ->
+        testSendNewsletterBpmnModel(processId = "sendNewsletter", variantName = name)
+            .let { model ->
+                model.copy(
+                    flowNodes = model.flowNodes.map { node ->
+                        if (node.id == "serviceTask_loadSubscribers") node.copy(displayName = "load-$name") else node
+                    },
+                )
+            }
+    }
+
+    @Test
+    fun `generates byte-identical code regardless of input order`() {
+
+        // given: every permutation we want to exercise (canonical, reversed, rotated)
+        val inputOrders = listOf(
+            variantNames,
+            variantNames.reversed(),
+            listOf("default", "waghaeusel", "kronstorf"),
+            listOf("kronstorf", "default", "waghaeusel"),
+        )
+
+        // when: generating from each order
+        val outputs = inputOrders.map { order -> generate(order) }
+
+        // then: all runs produce the exact same files with the exact same content
+        val reference = outputs.first()
+        assertThat(reference).isNotEmpty()
+        outputs.forEach { output ->
+            assertThat(output).isEqualTo(reference)
+        }
+    }
+
+    private fun generate(order: List<String>): List<GeneratedApiFile> {
+        order.forEach { name ->
+            every { bpmnService.extract(match<BpmnResource> { it.fileName == name }, any()) } returns modelsByName.getValue(name)
+        }
+        val command = GenerateProcessApiInMemoryUseCase.Command(
+            bpmnContents = order.map { BpmnInput(bpmnXml = "<bpmn>$it</bpmn>", processName = it) },
+            packagePath = "com.example",
+            outputLanguage = OutputLanguage.KOTLIN,
+            engine = ProcessEngine.ZEEBE,
+        )
+        return underTest.generateProcessApi(command)
+    }
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/application/service/GenerateProcessApiDeterministicOrderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/application/service/GenerateProcessApiDeterministicOrderTest.kt
@@ -31,7 +31,7 @@ class GenerateProcessApiDeterministicOrderTest {
 
     // Three variants of one process. Same shape, distinct variant names + a distinct node label so the
     // emitted variant blocks and the merged base node differ — a reorder would change bytes if unfixed.
-    private val variantNames = listOf("waghaeusel", "default", "kronstorf")
+    private val variantNames = listOf("staging", "dev", "prod")
 
     private val modelsByName: Map<String, BpmnModel> = variantNames.associateWith { name ->
         testSendNewsletterBpmnModel(processId = "sendNewsletter", variantName = name)
@@ -51,8 +51,8 @@ class GenerateProcessApiDeterministicOrderTest {
         val inputOrders = listOf(
             variantNames,
             variantNames.reversed(),
-            listOf("default", "waghaeusel", "kronstorf"),
-            listOf("kronstorf", "default", "waghaeusel"),
+            listOf("dev", "staging", "prod"),
+            listOf("prod", "dev", "staging"),
         )
 
         // when: generating from each order

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/service/ModelMergerServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/service/ModelMergerServiceTest.kt
@@ -364,6 +364,32 @@ class ModelMergerServiceTest {
     }
 
     @Test
+    fun `orders variants and base node selection deterministically regardless of input order`() {
+
+        // given: three variants of one process, each providing a different name for the shared node
+        fun variant(name: String) = testBpmnModel(
+            processId = "order-process",
+            variantName = name,
+            flowNodes = listOf(FlowNodeDefinition(id = "Task_Shared", displayName = "name-from-$name")),
+        )
+        val default = variant("default")
+        val kronstorf = variant("kronstorf")
+        val waghaeusel = variant("waghaeusel")
+
+        // when: merging the same set in two different input orders
+        val forward = underTest.mergeModels(listOf(default, kronstorf, waghaeusel)).first() as MergedBpmnModel
+        val shuffled = underTest.mergeModels(listOf(waghaeusel, default, kronstorf)).first() as MergedBpmnModel
+
+        // then: variants are emitted sorted by variantName, independent of input order
+        assertThat(forward.variants.map { it.variantName }).containsExactly("default", "kronstorf", "waghaeusel")
+        assertThat(shuffled.variants.map { it.variantName }).containsExactly("default", "kronstorf", "waghaeusel")
+
+        // and: the merged base node takes its attributes from the first variant by name ("default")
+        assertThat(forward.flowNodes.first { it.getRawName() == "Task_Shared" }.displayName).isEqualTo("name-from-default")
+        assertThat(shuffled.flowNodes.first { it.getRawName() == "Task_Shared" }.displayName).isEqualTo("name-from-default")
+    }
+
+    @Test
     fun `returns single model as BpmnModel`() {
 
         // given: a single model

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/service/ModelMergerServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/domain/service/ModelMergerServiceTest.kt
@@ -372,21 +372,21 @@ class ModelMergerServiceTest {
             variantName = name,
             flowNodes = listOf(FlowNodeDefinition(id = "Task_Shared", displayName = "name-from-$name")),
         )
-        val default = variant("default")
-        val kronstorf = variant("kronstorf")
-        val waghaeusel = variant("waghaeusel")
+        val dev = variant("dev")
+        val prod = variant("prod")
+        val staging = variant("staging")
 
         // when: merging the same set in two different input orders
-        val forward = underTest.mergeModels(listOf(default, kronstorf, waghaeusel)).first() as MergedBpmnModel
-        val shuffled = underTest.mergeModels(listOf(waghaeusel, default, kronstorf)).first() as MergedBpmnModel
+        val forward = underTest.mergeModels(listOf(dev, prod, staging)).first() as MergedBpmnModel
+        val shuffled = underTest.mergeModels(listOf(staging, dev, prod)).first() as MergedBpmnModel
 
         // then: variants are emitted sorted by variantName, independent of input order
-        assertThat(forward.variants.map { it.variantName }).containsExactly("default", "kronstorf", "waghaeusel")
-        assertThat(shuffled.variants.map { it.variantName }).containsExactly("default", "kronstorf", "waghaeusel")
+        assertThat(forward.variants.map { it.variantName }).containsExactly("dev", "prod", "staging")
+        assertThat(shuffled.variants.map { it.variantName }).containsExactly("dev", "prod", "staging")
 
-        // and: the merged base node takes its attributes from the first variant by name ("default")
-        assertThat(forward.flowNodes.first { it.getRawName() == "Task_Shared" }.displayName).isEqualTo("name-from-default")
-        assertThat(shuffled.flowNodes.first { it.getRawName() == "Task_Shared" }.displayName).isEqualTo("name-from-default")
+        // and: the merged base node takes its attributes from the first variant by name ("dev")
+        assertThat(forward.flowNodes.first { it.getRawName() == "Task_Shared" }.displayName).isEqualTo("name-from-dev")
+        assertThat(shuffled.flowNodes.first { it.getRawName() == "Task_Shared" }.displayName).isEqualTo("name-from-dev")
     }
 
     @Test

--- a/docs/contributing/adr/002-model-merging.md
+++ b/docs/contributing/adr/002-model-merging.md
@@ -24,9 +24,14 @@ All elements from variants are combined using `distinctBy { it.getName() }` to c
 - **Simpler integration**: One import instead of environment-specific APIs
 
 ### Negative
-- **Element conflicts**: If variants define the same element ID differently, last-seen wins silently
+- **Element conflicts**: If variants define the same element ID differently, one variant's attributes win silently
 - **API bloat**: Generated API may include elements not used in all environments
-- **Non-deterministic**: File processing order determines conflict resolution
+
+> **Update (2026-08):** Merging is now order-independent. Files are loaded in relative-path order and
+> variants are merged in `variantName` order, so the generated output is a deterministic function of
+> the `.bpmn` inputs — byte-identical across machines and filesystems. On an element conflict, the
+> base attributes come from the variant whose `variantName` sorts first (still ambiguous by design,
+> but no longer dependent on filesystem read order).
 
 ## Future Improvements
 - Detect and warn about element conflicts across variants

--- a/docs/contributing/best-practices.md
+++ b/docs/contributing/best-practices.md
@@ -141,7 +141,7 @@ OrderProcessApi (merged elements from both variants)
 **Be aware:**
 - Generated API contains the **superset** of all elements across variants
 - API may include elements not used in all environments
-- If variants define the same element ID differently, the behavior is non-deterministic (last-seen wins)
+- If variants define the same element ID differently, the merged base attributes come from the variant whose `variantName` sorts first alphabetically — a deterministic choice, but still ambiguous by design, so avoid it
 
 **Avoid:**
 - Defining the same element ID with different semantics across variants

--- a/docs/guide/verify-in-ci.md
+++ b/docs/guide/verify-in-ci.md
@@ -12,7 +12,7 @@ Because generation is **deterministic**, a CI job can regenerate the API and fai
   Your `outputFolderPath` points at a tracked source directory (e.g. `$projectDir/src/main/kotlin`), so there's a reference state to diff against.
   See [Configuration](/guide/configuration).
 - **Generation is deterministic.**
-  bpmn-to-code produces byte-identical output for the same input, so a re-run only changes files when the models actually changed.
+  bpmn-to-code produces byte-identical output for the same input — the generated code is a function of the `.bpmn` inputs alone, independent of the operating system and filesystem that read them. So a re-run only changes files when the models actually changed, and a macOS developer and a Linux CI runner produce the same result.
 
 ## GitHub Actions
 


### PR DESCRIPTION
## What & why

Generated Process APIs were **not reproducible**: for identical `.bpmn` inputs, macOS (APFS) and a Linux CI runner (ext4/overlayfs) produced different files — a pure permutation of the same content (~900 added / ~900 removed lines in a real consumer). This blocks the documented "regenerate + `git diff --exit-code`" CI drift-check.

**Root cause:** `BpmnFileLoader` collects files via `Files.walk` (no ordering guarantee), and that encounter order leaked downstream into the merger: the `object Variants { … }` block order and the base-node selection (`duplicates.first()`) followed whichever file was read first.

## Changes

- **`BpmnFileLoader`** — sort walked files by their **relative path** (segments joined with `/` for an OS-independent, locale-independent key). Relative path, not file name, because variant files legitimately share a file name across directories.
- **`ModelMergerService`** — remove input-order dependence:
  - emit merged processes sorted by `processId`
  - sort variants by `variantName` (fixes both the `Variants` block order and the base-node attribute selection, now documented in KDoc)
  - sort the `attachedElements` union
- **Docs** — strengthen the determinism guarantee in the CI guide; correct the now-inaccurate "non-deterministic / last-seen wins" wording in best-practices and ADR 002.

The in-memory and JSON generation paths ride on the same loader + merger, so they are covered without further changes.

## Tests

- `BpmnFileLoaderTest` — duplicate file names across sibling folders return in relative-path order.
- `ModelMergerServiceTest` — variants and base-node selection deterministic across input orders.
- `GenerateProcessApiDeterministicOrderTest` (new) — regression guard: same multi-variant model set through the in-memory service (real codegen) in several fixed input orders → byte-identical output. Confirmed it fails without the fix.

All core, architecture, gradle, maven, and testing module tests pass.

## Release note (breaking-ish, one-time)

Variant order becomes stable, so the **first regeneration after upgrading reorders existing generated files** (no semantic change). Consumers should regenerate and commit once.