### PR TITLE
feat(core): bundle process-model JSON schema in the jar

### DIFF
--- a/bpmn-to-code-core/build.gradle.kts
+++ b/bpmn-to-code-core/build.gradle.kts
@@ -22,7 +22,6 @@ dependencies {
     testImplementation(libs.bundles.testing)
     testImplementation(kotlin("compiler-embeddable"))
     testImplementation(libs.jsonSchemaValidator)
-    // Lets the codegen tests compile generated output for real (not just parse) against the runtime interfaces.
     testImplementation(project(":bpmn-to-code-runtime"))
     testRuntimeOnly(libs.junitPlatformLauncher)
 }
@@ -30,22 +29,24 @@ dependencies {
 sourceSets {
     test {
         resources.srcDir(rootProject.file("shared"))
-        // The published JSON schema, so ProcessJsonSchemaTest validates against it offline
         resources.srcDir(rootProject.file("docs/public/schema"))
+    }
+}
+
+tasks.processResources {
+    from(rootProject.file("docs/public/schema")) {
+        into("META-INF/bpmn-to-code/schema")
     }
 }
 
 tasks.named<Test>("test") {
     useJUnitPlatform()
-    // Lets `./gradlew test -Dgolden.update=true` rewrite the end-to-end JSON snapshots.
     systemProperty("golden.update", System.getProperty("golden.update") ?: "false")
 }
 
 private val coverageExclusions = listOf(
     "**/domain/shared/**",
     "**/domain/validation/model/**",
-    // Constant holders: their `const val`s are inlined at the call site, so the object itself
-    // never executes. Matched by name rather than by package so a move cannot silently re-include them.
     "**/adapter/outbound/engine/**/*Constants*",
     "**/adapter/outbound/json/model/**",
     "**/application/port/**",

--- a/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/json/ProcessJsonSchemaTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/miragon/bpmn/adapter/outbound/json/ProcessJsonSchemaTest.kt
@@ -30,7 +30,7 @@ class ProcessJsonSchemaTest {
 
     private val schema = JsonSchemaFactory
         .getInstance(SpecVersion.VersionFlag.V202012)
-        .getSchema(requireNotNull(javaClass.getResourceAsStream("/process-model/2.0.json")))
+        .getSchema(requireNotNull(javaClass.getResourceAsStream("/META-INF/bpmn-to-code/schema/process-model/2.0.json")))
 
     @ParameterizedTest
     @EnumSource(ProcessEngine::class)


### PR DESCRIPTION
## What

Ships the process-model JSON schema inside the `bpmn-to-code-core` JAR at a stable classpath location:

```
META-INF/bpmn-to-code/schema/process-model/2.0.json
```

Consumers can now load it off the classpath instead of hardcoding the JSON structure:

```kotlin
javaClass.getResourceAsStream("/META-INF/bpmn-to-code/schema/process-model/2.0.json")
```

## Why

A downstream consumer generates test facades from our process JSON and today traverses it with hardcoded strings. Having the schema on the classpath lets them codegen against the actual contract.

## How

- `processResources` maps the existing `docs/public/schema` dir into the core main resources under the `META-INF` prefix — **no file is duplicated**; it stays the same single source docs publishes at the `$schema` URL.
- `ProcessJsonSchemaTest` now validates against the packaged classpath path, proving the exact JAR entry is correct.

Not a breaking change.