### PR TITLE
chore: keep install-snippet versions in sync via release-please

### DIFF
--- a/.claude/skills/bpmn-to-code-release/SKILL.md
+++ b/.claude/skills/bpmn-to-code-release/SKILL.md
@@ -11,7 +11,7 @@ Releases are automated by [release-please](https://github.com/googleapis/release
 ## Normal flow
 
 1. **Conventional commits land on `main`.** `feat:` → minor, `fix:` → patch, `feat!:` / `BREAKING CHANGE` → major. Other types (`chore`, `docs`, `refactor`, `build`, `test`, …) do not bump.
-2. **Release-please opens / updates a PR** titled `chore(main): release <next-version>`. It touches only `gradle.properties`, `CHANGELOG.md`, and `.release-please-manifest.json`.
+2. **Release-please opens / updates a PR** titled `chore(main): release <next-version>`. It bumps `gradle.properties`, `CHANGELOG.md`, `.release-please-manifest.json`, and — via the `extra-files` list in `release-please-config.json` — the version in every install snippet in the READMEs and `docs/` (each wrapped in invisible `<!-- x-release-please-start-version -->` / `<!-- x-release-please-end -->` HTML-comment markers). Version-specific migration guides and ADRs are intentionally **not** registered and stay untouched.
 3. **Merge the Release PR** when you want to ship.
 4. **A published GitHub Release is created** (tag `v<version>` created atomically) with notes generated from the commits. The release is *not* a draft — publishing immediately is what guarantees the tag exists, which release-please needs to anchor the next changelog.
 5. **The same `Release` workflow run continues and pauses at the `release` approval gate.** Publishing is no longer a separate workflow reacting to the published release — the publish jobs run in the *same* run via `needs` + `release_created`. Open the workflow run and **approve the deployment** (or reject to abort). This is the human gate — it replaces the old "publish the draft" step.

--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ Works with Claude Code out of the box.
 
 ## Gradle Setup
 
+<!-- x-release-please-start-version -->
 ```kotlin
 plugins {
-    id("io.miragon.bpmn-to-code-gradle") version "6.0.0"
+    id("io.miragon.bpmn-to-code-gradle") version "5.2.0"
 }
 
 tasks.named("generateBpmnModelApi", GenerateBpmnModelsTask::class) {
@@ -99,14 +100,16 @@ tasks.named("generateBpmnModelApi", GenerateBpmnModelsTask::class) {
     processEngine = ProcessEngine.ZEEBE
 }
 ```
+<!-- x-release-please-end -->
 
 ## Maven Setup
 
+<!-- x-release-please-start-version -->
 ```xml
 <plugin>
     <groupId>io.miragon</groupId>
     <artifactId>bpmn-to-code-maven</artifactId>
-    <version>6.0.0</version>
+    <version>5.2.0</version>
     <executions>
         <execution>
             <goals><goal>generate-bpmn-api</goal></goals>
@@ -122,14 +125,17 @@ tasks.named("generateBpmnModelApi", GenerateBpmnModelsTask::class) {
     </configuration>
 </plugin>
 ```
+<!-- x-release-please-end -->
 
 ## Testing Module
 
+<!-- x-release-please-start-version -->
 ```kotlin
 dependencies {
-    testImplementation("io.miragon:bpmn-to-code-testing:6.0.0")
+    testImplementation("io.miragon:bpmn-to-code-testing:5.2.0")
 }
 ```
+<!-- x-release-please-end -->
 
 ## Supported Languages
 

--- a/bpmn-to-code-gradle/README.md
+++ b/bpmn-to-code-gradle/README.md
@@ -12,11 +12,13 @@ and ensure consistency between your BPMN model and your code.
 
 To get started, apply the plugin in your build.gradle.kts file:
 
+<!-- x-release-please-start-version -->
 ```kotlin
 plugins {
-    id("io.miragon.bpmn-to-code-gradle") version "3.0.0"
+    id("io.miragon.bpmn-to-code-gradle") version "5.2.0"
 }
 ```
+<!-- x-release-please-end -->
 
 If the plugin can not be found yet, please make sure,
 that you've also added the gradle plugin repository to your settings.gradle.kts file:

--- a/bpmn-to-code-maven/README.md
+++ b/bpmn-to-code-maven/README.md
@@ -13,19 +13,22 @@ and ensure consistency between your BPMN model and your code.
 Add the `bpmn-to-code-runtime` dependency (it ships the shared types — `ProcessId`, `ElementId`, `MessageName`,
 `SignalName`, `VariableName`, and the BPMN metadata records — that the generated code references):
 
+<!-- x-release-please-start-version -->
 ```xml
 <dependencies>
     <dependency>
         <groupId>io.miragon</groupId>
         <artifactId>bpmn-to-code-runtime</artifactId>
-        <version>3.0.0</version>
+        <version>5.2.0</version>
     </dependency>
 </dependencies>
 ```
+<!-- x-release-please-end -->
 
 Then add the plugin configuration within the `<build>` section. It tells the plugin where to locate your
 BPMN files, where to output the generated API files, and how to format the output (language, package, engine).
 
+<!-- x-release-please-start-version -->
 ```xml
 
 <build>
@@ -33,7 +36,7 @@ BPMN files, where to output the generated API files, and how to format the outpu
         <plugin>
             <groupId>io.miragon</groupId>
             <artifactId>bpmn-to-code-maven</artifactId>
-            <version>3.0.0</version>
+            <version>5.2.0</version>
             <executions>
                 <execution>
                     <goals>
@@ -53,6 +56,7 @@ BPMN files, where to output the generated API files, and how to format the outpu
     </plugins>
 </build>
 ```
+<!-- x-release-please-end -->
 
 Once configured, bpmn-to-code-maven processes your BPMN files and generates type-safe API references that
 you can seamlessly integrate into your application—whether for testing, messaging, or managing worker tasks.

--- a/docs/getting-started/gradle.md
+++ b/docs/getting-started/gradle.md
@@ -4,21 +4,23 @@ The bpmn-to-code Gradle plugin generates type-safe Process API files from your B
 
 ## 1. Apply the plugin
 
+<!-- x-release-please-start-version -->
 ::: code-group
 
 ```kotlin [build.gradle.kts]
 plugins {
-    id("io.miragon.bpmn-to-code-gradle") version "6.0.0"
+    id("io.miragon.bpmn-to-code-gradle") version "5.2.0"
 }
 ```
 
 ```groovy [build.gradle]
 plugins {
-    id 'io.miragon.bpmn-to-code-gradle' version '6.0.0'
+    id 'io.miragon.bpmn-to-code-gradle' version '5.2.0'
 }
 ```
 
 :::
+<!-- x-release-please-end -->
 
 Make sure the Gradle Plugin Portal is in your `settings.gradle.kts`:
 

--- a/docs/getting-started/maven-advanced.md
+++ b/docs/getting-started/maven-advanced.md
@@ -6,11 +6,12 @@ bpmn-to-code itself doesn't support excluding specific files or running multiple
 
 Add separate `<execution>` blocks with their own `<configuration>` to generate from different file sets or engines:
 
+<!-- x-release-please-start-version -->
 ```xml
 <plugin>
     <groupId>io.miragon</groupId>
     <artifactId>bpmn-to-code-maven</artifactId>
-    <version>6.0.0</version>
+    <version>5.2.0</version>
     <executions>
         <!-- Camunda 7 processes -->
         <execution>
@@ -41,6 +42,7 @@ Add separate `<execution>` blocks with their own `<configuration>` to generate f
     </executions>
 </plugin>
 ```
+<!-- x-release-please-end -->
 
 Both executions run automatically during `mvn compile`.
 
@@ -48,6 +50,7 @@ Both executions run automatically during `mvn compile`.
 
 bpmn-to-code processes all files matching the `filePattern` glob — it has no built-in include/exclude logic. If you need to exclude specific files, use the [maven-resources-plugin](https://maven.apache.org/plugins/maven-resources-plugin/) to copy only the files you want into a staging directory, then point bpmn-to-code at that directory:
 
+<!-- x-release-please-start-version -->
 ```xml
 <!-- 1. Copy only the BPMN files you want -->
 <plugin>
@@ -80,7 +83,7 @@ bpmn-to-code processes all files matching the `filePattern` glob — it has no b
 <plugin>
     <groupId>io.miragon</groupId>
     <artifactId>bpmn-to-code-maven</artifactId>
-    <version>6.0.0</version>
+    <version>5.2.0</version>
     <executions>
         <execution>
             <goals><goal>generate-bpmn-api</goal></goals>
@@ -96,5 +99,6 @@ bpmn-to-code processes all files matching the `filePattern` glob — it has no b
     </configuration>
 </plugin>
 ```
+<!-- x-release-please-end -->
 
 The [maven-resources-plugin](https://maven.apache.org/plugins/maven-resources-plugin/) runs first (during `generate-sources`), then bpmn-to-code generates from the filtered files.

--- a/docs/getting-started/maven.md
+++ b/docs/getting-started/maven.md
@@ -6,13 +6,14 @@ The bpmn-to-code Maven plugin generates type-safe Process API files from your BP
 
 Add the following to the `<build>` section of your `pom.xml`:
 
+<!-- x-release-please-start-version -->
 ```xml
 <build>
     <plugins>
         <plugin>
             <groupId>io.miragon</groupId>
             <artifactId>bpmn-to-code-maven</artifactId>
-            <version>6.0.0</version>
+            <version>5.2.0</version>
             <executions>
                 <execution>
                     <goals>
@@ -32,6 +33,7 @@ Add the following to the `<build>` section of your `pom.xml`:
     </plugins>
 </build>
 ```
+<!-- x-release-please-end -->
 
 See [Configuration](/guide/configuration) for all available parameters.
 

--- a/docs/surface/json.md
+++ b/docs/surface/json.md
@@ -312,11 +312,12 @@ Run:
 
 ### Maven
 
+<!-- x-release-please-start-version -->
 ```xml
 <plugin>
     <groupId>io.miragon</groupId>
     <artifactId>bpmn-to-code-maven</artifactId>
-    <version>6.0.0</version>
+    <version>5.2.0</version>
     <executions>
         <execution>
             <id>generate-bpmn-json</id>
@@ -331,6 +332,7 @@ Run:
     </executions>
 </plugin>
 ```
+<!-- x-release-please-end -->
 
 ## Parameters
 

--- a/docs/validate/index.md
+++ b/docs/validate/index.md
@@ -63,11 +63,12 @@ BPMN validation failed: 1 error(s), 1 warning(s)
 
 ### Configuration
 
+<!-- x-release-please-start-version -->
 ```xml
 <plugin>
     <groupId>io.miragon</groupId>
     <artifactId>bpmn-to-code-maven</artifactId>
-    <version>6.0.0</version>
+    <version>5.2.0</version>
     <executions>
         <execution>
             <id>validate-bpmn</id>
@@ -87,6 +88,7 @@ BPMN validation failed: 1 error(s), 1 warning(s)
     </executions>
 </plugin>
 ```
+<!-- x-release-please-end -->
 
 ### Running
 

--- a/docs/validate/testing.md
+++ b/docs/validate/testing.md
@@ -10,11 +10,12 @@ Add it to your test scope, write a test, and your CI will catch modeling issues 
 
 ## Dependency
 
+<!-- x-release-please-start-version -->
 ::: code-group
 
 ```kotlin [Gradle]
 dependencies {
-    testImplementation("io.miragon:bpmn-to-code-testing:6.0.0")
+    testImplementation("io.miragon:bpmn-to-code-testing:5.2.0")
 }
 ```
 
@@ -22,12 +23,13 @@ dependencies {
 <dependency>
     <groupId>io.miragon</groupId>
     <artifactId>bpmn-to-code-testing</artifactId>
-    <version>6.0.0</version>
+    <version>5.2.0</version>
     <scope>test</scope>
 </dependency>
 ```
 
 :::
+<!-- x-release-please-end -->
 
 ## Basic Usage
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,10 +9,16 @@
       "package-name": "bpmn-to-code",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        {
-          "type": "generic",
-          "path": "gradle.properties"
-        }
+        { "type": "generic", "path": "gradle.properties" },
+        { "type": "generic", "path": "README.md" },
+        { "type": "generic", "path": "bpmn-to-code-gradle/README.md" },
+        { "type": "generic", "path": "bpmn-to-code-maven/README.md" },
+        { "type": "generic", "path": "docs/getting-started/gradle.md" },
+        { "type": "generic", "path": "docs/getting-started/maven.md" },
+        { "type": "generic", "path": "docs/getting-started/maven-advanced.md" },
+        { "type": "generic", "path": "docs/validate/index.md" },
+        { "type": "generic", "path": "docs/validate/testing.md" },
+        { "type": "generic", "path": "docs/surface/json.md" }
       ]
     }
   }


### PR DESCRIPTION
## What & why

Version numbers were scattered and contradictory: the authoritative version (`gradle.properties` = `5.2.0`, matching tag `v5.2.0`) was bumped by release-please, but every hand-maintained install snippet had drifted — the top-level README and all docs said `6.0.0`, the module READMEs said `3.0.0`.

Root cause: release-please only listed `gradle.properties` in `extra-files`, so nothing else stayed in sync.

## Changes

- Reconcile every install snippet to the published **5.2.0** (README.md, both module READMEs, `docs/getting-started/*`, `docs/validate/*`, `docs/surface/json.md`).
- Wrap each snippet in invisible `<!-- x-release-please-start-version -->` / `<!-- x-release-please-end -->` HTML-comment markers (outside the code fence, so nothing renders in the copy-paste block).
- Register those files as `generic` `extra-files` in `release-please-config.json`, so the standing Release PR now bumps them **atomically** with `gradle.properties`.
- Update the release skill to reflect that the Release PR now also bumps the README/docs snippets.

Version-specific migration guides and ADRs (e.g. `docs/changelog/v6.md`, prose like "Since 6.0.0 the format …") are intentionally left untouched.

## Verification

- `release-please-config.json` remains valid JSON.
- No `6.0.0`/`3.0.0` left in install snippets (only the intentional historical prose reference).
- Start/end markers balanced (13/13).
- End-to-end: the next Release PR will show all registered files updated with the new version (previewable via the `release-please.yml` `workflow_dispatch` dry run).
